### PR TITLE
36 运行时记忆原子草稿态与缓存

### DIFF
--- a/docs/components/generation.md
+++ b/docs/components/generation.md
@@ -186,11 +186,11 @@ draft = ExtractedMemoryDraft(
 当 Worker Agent 通过 MTP 协议发出 `UPDATE` 指令时触发。Agent 请求修改一条已有记忆，Patchouli 执行智能合并。
 
 ```
-MTP UPDATE 指令 → UpdateFocus(instruction, content, target_alias) → Mode C 流程
+MTP UPDATE 指令 → UpdateFocus(instruction, content, base_alias, base_uuid) → Mode C 流程
 ```
 
 **流程**：
-1. 由 Koakuma 解析 `target_alias`，从 Storage 加载目标 `MemoryAtom`，注入 `UpdateFocus.existing_memory`。
+1. 由 Koakuma 解析 `base_alias`，生成携带 `base_alias/base_uuid` 的 `UpdateFocus`；LibrarianCore 在进入 Mode C 前根据 `base_uuid` 加载目标 `MemoryAtom`，并注入 `GenerationRequest.existing_memory`。
 2. 调用 `extractor.merge()`，使用 **Mode C Prompt** 执行 LLM 驱动的智能合并。
 3. LLM 输出 `MergeResult { new_content, changelog }`。
 4. 执行版本历史追踪：旧内容压入 `artifacts.full_history`，新内容覆盖 `payload.content`，版本号 +1。

--- a/docs/mod/PendingAtomCacheDesign.md
+++ b/docs/mod/PendingAtomCacheDesign.md
@@ -200,6 +200,68 @@ PendingAtomRegistry
   -> Durable PendingAtomLedger
 ```
 
+## 4.4 Intent Identity 与 Focus 绑定
+
+Phase 2 中，`intent_id` 用于标识一次系统内部的记忆生成意图，`pending_alias` 用于提供给 Agent 的运行时可寻址句柄。二者应在同一时刻生成并绑定，但语义上保持分离。
+
+- `pending_alias` 面向 Agent，可出现在 MTP 回填、`READ`、`context_refs` 和子 Agent artifact transfer 中
+- `intent_id` 面向系统内部，用于贯穿 Koakuma、ArchivePayload、LibrarianCore、GenerationEngine、Deduplicator 和 settlement 回填链路
+- `intent_id` 不从 `pending_alias` 派生，避免 alias canonicalization 后形成不必要耦合
+- `intent_id` 不属于 `RuntimeScope`；`RuntimeScope` 描述执行坐标，`intent_id` 描述记忆生成意图
+
+生成责任应收束在 Alice runtime 的 pending 注册点：
+
+```text
+Koakuma handles WRITE/UPDATE
+  -> PendingAtomCache.register_write/register_update()
+  -> system generates pending_alias + intent_id
+  -> PendingAtom stores pending_alias + intent_id
+  -> Koakuma builds WriteFocus/UpdateFocus with the same pending_alias + intent_id
+  -> Focus travels into Patchouli generation
+  -> Generation result / settlement returns intent_id
+  -> PendingAtomCache resolves intent_id back to pending_alias
+```
+
+Patchouli 侧只消费 `intent_id`，不负责创建或覆盖它。即使未来 MTP 参数中出现同名字段，也应忽略或拒绝，避免 Agent 越权伪造系统内部意图标识。
+
+`WriteFocus` / `UpdateFocus` 应携带该绑定关系：
+
+```python
+class WriteFocus:
+    content: str
+    reason: str | None
+    title: str | None
+    identity: Identity
+    pending_alias: str | None
+    intent_id: str | None
+
+
+class UpdateFocus:
+    instruction: str
+    content: str | None
+    target_uuid: str
+    target_alias: str
+    existing_memory: MemoryAtom | None
+    identity: Identity
+    pending_alias: str | None
+    intent_id: str | None
+```
+
+建议格式：
+
+```text
+intent_id = intent_{short_uuid_or_ulid}
+```
+
+该绑定使 Phase 2 的反向索引可以稳定表达为：
+
+```text
+pending_alias -> intent_id
+intent_id -> pending_alias
+intent_id -> settlement
+canonical_uuid -> [pending_alias...]
+```
+
 ---
 
 ## 5. Alias 策略
@@ -382,8 +444,8 @@ Agent:
 
 Koakuma:
   1. 校验 WRITE 权限与参数
-  2. 生成 pending_alias
-  3. 创建 PendingAtom(status=PENDING)
+  2. 生成 pending_alias / intent_id
+  3. 创建 PendingAtom(status=PENDING)，绑定 pending_alias / intent_id
   4. 写入 PendingAtomCache
   5. 构造 WriteFocus，附带 pending_alias / intent_id
   6. 返回 ACK
@@ -394,13 +456,6 @@ Koakuma:
 ```text
 Memory accepted as pending atom 'draft_login_api_7f3a'.
 It is readable during this run. Final memory generation will complete asynchronously.
-```
-
-`WriteFocus` 建议增加：
-
-```python
-pending_alias: str | None
-intent_id: str | None
 ```
 
 ---
@@ -438,7 +493,7 @@ MVP 建议：
 
 ## 10. RuntimeAliasResolver 与 READ 解析优先级
 
-后续应引入统一的 `RuntimeAliasResolver` 管理运行时 alias 解析。它负责协调三级缓存命中路径，而不是让 `READ`、`RUN`、`UPDATE` 各自维护分散解析逻辑。
+应引入统一的 `RuntimeAliasResolver` 管理运行时 alias 解析。它负责协调三级缓存命中路径，而不是让 `READ`、`RUN`、`UPDATE` 各自维护分散解析逻辑。
 
 目标解析顺序：
 
@@ -615,6 +670,35 @@ class PendingAtomSettlement:
     reason: str | None
 ```
 
+`PendingAtomSettlement` 表示 pending intent 的结算视图，不应替代 generation 的完整返回结果。被动对话整理链路没有 pending alias，也不需要 settlement；只有 MTP `WRITE` / `UPDATE` 触发的主动写入链路，在 `WriteFocus` / `UpdateFocus` 携带 `pending_alias` 与 `intent_id` 时，才会生成 settlement。
+
+因此，GenerationEngine 建议重置返回模型为 `MemoryGenerationResult`，并返回 `list[MemoryGenerationResult]`：
+
+```python
+class MemoryGenerationResult:
+    intent_id: str | None
+    pending_alias: str | None
+
+    atom: MemoryAtom | None
+    canonical_alias: str | None
+    canonical_uuid: str | None
+
+    duplicate_decision: Literal["CREATE", "UPDATE", "TOUCH", "DISCARD"] | None
+    operation: Literal["created", "merged", "touched", "discarded", "updated", "failed"]
+
+    settlement: PendingAtomSettlement | None
+    message: str | None
+    error: str | None
+```
+
+语义约束：
+
+- `GenerationEngine` 是最接近 Deduplicator 决策与持久化结果的组件，应负责产出结构化 `MemoryGenerationResult`
+- `KoakumaRuntime` 不应在事后根据返回 atom 重新推断 settlement
+- `settlement` 是 pending intent 存在时附加产生的结算视图；被动生成结果中 `settlement=None`
+- 现有 `list[MemoryAtom]` 返回值意义有限，可在 Phase 2 中替换为 `list[MemoryGenerationResult]`
+- 为避免与 Alice runtime 中表示 LLM 文本输出的 `GenerationResult` 混淆，生成引擎侧建议使用 `MemoryGenerationResult` 命名
+
 ### 14.1 Deduplicator 决策映射
 
 `PendingAtomCache` 的 settlement 状态与 Deduplicator 决策建议按以下方式映射：
@@ -687,10 +771,50 @@ Pending atom 'draft_login_api_7f3a' was not materialized.
 Reason: content was too low-value or invalid for long-term memory.
 ```
 
-### 14.4 仍需明确的问题
+### 14.4 Settlement 回填方式
 
-- `GenerationEngine.process()` 如何返回 pending settlement
-- `LibrarianCore._on_generate_memory()` 在完成后由谁调用 registry settle
+Settlement 回填应通过系统总线完成，避免 Patchouli 与 Alice runtime 形成直接对象依赖。
+
+现有 `AsyncSystemBus` 已支持 `subscribe()` / `publish()`，因此 Phase 2 可以使用全局事件广播：
+
+```text
+GenerationEngine
+  -> returns list[MemoryGenerationResult]
+
+LibrarianCore / PatchouliRuntime
+  -> extracts result.settlement
+  -> global_bus.publish(PENDING_ATOM_SETTLED, settlement)
+
+AliceRuntime
+  -> subscribes PENDING_ATOM_SETTLED
+  -> PendingAtomCache.apply_settlement(settlement)
+  -> optionally updates KoakumaAtomCache
+
+RuntimeAliasResolver
+  -> reads PendingAtomCache redirect / settlement state during resolve()
+```
+
+建议事件名：
+
+```python
+class GlobalEvents:
+    PENDING_ATOM_SETTLED = "alice.events.pending_atom.settled"
+```
+
+职责划分：
+
+- `GenerationEngine` 不直接持有 bus，只返回 `MemoryGenerationResult`
+- `LibrarianCore` 或 Patchouli runtime 负责把 settlement publish 到 `GlobalSystemBus`
+- `AliceRuntime` 作为 runtime 聚合根负责订阅、退订与异常隔离
+- `RuntimeAliasResolver` 不直接订阅总线；它只在解析 alias 时读取 `PendingAtomCache` 中的 settlement / redirect 状态
+- `PendingAtomCache` 负责根据 settlement 更新状态、反向索引与 canonical redirect
+
+该事件是 runtime 回填事件，不是正式记忆落库的成功判定。正式状态仍以 storage 为准。当前 `publish()` 是内存广播，没有持久化与重放能力；这与 Phase 2 仍以 runtime cache 为主的目标一致。未来引入 `PendingAtomLedger` 或统一事件流后，可将同一 settlement event 接入持久化管道。
+
+如果后续要求 Patchouli 必须确认 Alice 已处理 settlement，可以演进为 RPC route，例如 `alice.public.pending_atom.settle`。但 MVP 更推荐 pub/sub：Alice 不在线或订阅失败时，只影响运行时 redirect，不阻塞正式记忆生成与落库。
+
+### 14.5 仍需明确的问题
+
 - 如果 extraction 阶段从一个 pending intent 中提取出多条 draft，是否允许一个 pending alias 对应多个正式 atom
 
 MVP 可以先做 best-effort settle：
@@ -826,14 +950,16 @@ WRITE accepted -> draft_xxx pending -> mem_xxx committed
 
 范围：
 
-1. `GenerationRequest` 携带 `intent_id` / `pending_alias`
-2. `GenerationEngine` 返回 `PendingAtomSettlement`
+1. `WriteFocus/UpdateFocus` 携带 `intent_id` / `pending_alias`
+2. `GenerationEngine` 返回 `list[MemoryGenerationResult]`
 3. settlement 保留 `duplicate_decision`
-4. `PendingAtomCache` 根据 settlement 更新状态
-5. pending alias 物化后进入 redirect grace period
-6. `READ` / `RUN` / `UPDATE` / `context_refs` 对 redirect alias 做 canonicalization
-7. `SEARCH` 只暴露 canonical alias，不暴露已 redirect 的 pending alias
-8. `READ redirected_alias` 渲染 canonical atom，并提示后续使用 canonical alias
+4. `LibrarianCore` / Patchouli runtime 通过 `GlobalSystemBus.publish()` 回填 settlement
+5. `AliceRuntime` 订阅 settlement event，并调用 `PendingAtomCache.apply_settlement()`
+6. `PendingAtomCache` 根据 settlement 更新状态
+7. pending alias 物化后进入 redirect grace period
+8. `READ` / `RUN` / `UPDATE` / `context_refs` 对 redirect alias 做 canonicalization
+9. `SEARCH` 只暴露 canonical alias，不暴露已 redirect 的 pending alias
+10. `READ redirected_alias` 渲染 canonical atom，并提示后续使用 canonical alias
 
 验收标准：
 

--- a/docs/mod/PendingAtomCacheDesign.md
+++ b/docs/mod/PendingAtomCacheDesign.md
@@ -1,0 +1,891 @@
+# PendingAtomCache 与运行时 Shadow Memory 设计草案
+
+**文档状态**: Draft (草案)  
+**适用范围**: MTP `WRITE` / `UPDATE`、Koakuma Runtime、Agent Loop、Sub-Agent CALL、Patchouli 异步记忆生成链路  
+**核心目标**: 在不破坏异步记忆生成原则的前提下，为 Agent run 提供可立即读取、可传递、可结算的运行时记忆句柄。
+
+---
+
+## 1. 文档目标
+
+本文用于整理 `PendingAtomCache` 及相关运行时流程的初始设计。该设计围绕一个已经显现的系统问题展开：
+
+> Agent 在运行时通过 MTP `WRITE` / `UPDATE` 提交记忆生成意图后，系统会立即回填成功响应，但真正的记忆原子仍由帕秋莉在后台异步生成。此时 Agent 缺少一个可寻址入口，无法在同一 run 内读取刚刚提交的内容，也无法稳定收割子 Agent 产生的 artifacts。
+
+本文的目标不是把记忆生成改回同步模式，而是为异步生成链路补上一层运行时可见性：
+
+- `WRITE` / `UPDATE` 同步创建可读的 pending handle
+- Agent 可以在同一 run 内立刻 `READ` 该 handle
+- 子 Agent 产生的 pending artifacts 可以在 `CALL` 结束后返回给主 Agent，并在当前阶段转为主 Agent 可管理的运行时资产
+- 后台生成完成后，pending handle 可以结算到正式 `MemoryAtom`
+- 结算失败或去重合并时，Agent 仍能获得清晰状态
+
+---
+
+## 2. 当前问题
+
+当前 MTP `WRITE` / `UPDATE` 的语义接近：
+
+```text
+Agent emits WRITE/UPDATE
+  -> Koakuma captures WriteFocus/UpdateFocus
+  -> returns ACK to Agent
+  -> LoopExecutor records focus
+  -> InteractionPayload enters Perception
+  -> Flush triggers Librarian generation asynchronously
+  -> GenerationEngine creates/updates MemoryAtom later
+```
+
+这条链路保留了冷路径异步生成的优点，但存在几个运行时缺口：
+
+1. **ACK 与真实落库之间存在语义落差**
+   - 回填文本可能暗示“记忆已保存”
+   - 实际上此时只有 `WriteFocus` / `UpdateFocus` 被捕获，正式原子尚未生成
+
+2. **Agent 无法立即读取新提交内容**
+   - `READ` 只能解析已有 alias
+   - 对于尚未生成的原子，没有 alias 可供读取
+
+3. **子 Agent artifact 收割不稳定**
+   - 子 Agent 内部 `WRITE` 触发后，主 Agent 返回时正式 atom 可能尚未生成
+   - 当前 `WRITE` 分支无法可靠完成 artifact 归属转移
+
+4. **多次 WRITE/UPDATE 可能被覆盖**
+   - 当前 `ChatResult.write_focus` / `update_focus` 是单值语义
+   - 长 run 内多次主动写入时，需要支持列表化聚合
+
+---
+
+## 3. OS 类比与设计启发
+
+该问题与现代操作系统中的异步 IO、缓存写回和句柄可见性问题高度相似。
+
+### 3.1 Page Cache / Write-back
+
+OS 中应用调用 `write()` 后，数据通常先进入 page cache，随后由内核异步 flush 到磁盘。应用如果马上 `read()`，读到的是 page cache 中的最新内容，而不是磁盘上的旧内容。
+
+HiveMemory 可借鉴该模型：
+
+```text
+OS write() -> page cache -> async disk flush
+MTP WRITE  -> pending atom -> async memory generation/storage
+```
+
+这里的 pending atom 不是“假数据”，而是尚未写回长期存储的运行时可见数据。
+
+### 3.2 File Descriptor / Handle
+
+OS 通过 fd 向进程返回稳定句柄。进程后续读写依赖 fd，而不需要关心文件最终位于哪个磁盘 block。
+
+HiveMemory 中，`WRITE` 应返回稳定的运行时句柄：
+
+```text
+draft_login_api_7f3a
+rev_mem_login_api_spec_b921
+```
+
+Agent 使用该 alias 继续 `READ`。子 Agent 产生的 alias 会在 `CALL` 结束后回填给主 Agent，并在当前多智能体阶段下转为主 Agent 的运行时资产。
+
+### 3.3 WAL / Intent Log
+
+数据库与 journaling filesystem 通常先记录操作意图，再异步更新真实数据结构。
+
+HiveMemory 中应区分：
+
+- **控制面**: 同步记录 pending intent，生成可读句柄
+- **数据面**: 异步执行帕秋莉生成、去重、合并、入库
+
+### 3.4 Completion Queue
+
+异步 IO 系统通常通过 completion event 通知请求最终状态。
+
+HiveMemory 中需要一个 settlement 机制：
+
+```text
+pending_alias=draft_login_api_7f3a
+status=COMMITTED
+final_alias=mem_login_api_spec
+final_uuid=...
+```
+
+---
+
+## 4. 核心抽象
+
+## 4.1 PendingAtom
+
+`PendingAtom` 表示一个运行时可读的记忆生成句柄。
+
+它不是正式 `MemoryAtom`，也不承诺最终一定落库。它的承诺是：
+
+> 在其生命周期内，Agent 可以通过 pending alias 读取到本次 MTP 写入或更新意图的内容、元数据和当前生成状态。
+
+建议语义定义：
+
+```text
+PendingAtom = a runtime-readable materialization handle for a memory intent.
+```
+
+建议字段：
+
+```python
+class PendingAtom:
+    pending_alias: str
+    intent_id: str
+    source_verb: Literal["WRITE", "UPDATE"]
+    status: PendingAtomStatus
+
+    title: str | None
+    content: str
+    reason: str | None
+    instruction: str | None
+
+    target_alias: str | None
+    target_uuid: str | None
+
+    identity: Identity
+    run_id: str
+    frame_id: str
+    parent_frame_id: str | None
+    action_id: str | None
+    agent_alias: str | None
+    depth: int
+
+    created_at: datetime
+    updated_at: datetime
+    expires_at: datetime | None
+
+    final_alias: str | None
+    final_uuid: str | None
+    error: str | None
+```
+
+## 4.2 PendingAtomCache
+
+`PendingAtomCache` 是运行时快速查询层，职责类似 page cache：
+
+- 同步注册 pending atom
+- 通过 pending alias 查询 pending atom
+- 支持 alias redirect / tombstone
+- 支持按 run/frame 清理
+- 支持结算后更新状态
+
+当前阶段 `PendingAtomCache` 仅作为普通 runtime cache 实现，不引入持久化 ledger。它服务于单次 Agent run 及其子 frame 的运行时可见性，不承担跨进程恢复、审计追踪和完整事件溯源职责。
+
+建议先实现为内存结构：
+
+```text
+pending_alias -> PendingAtom
+final_alias -> pending_alias? (optional)
+intent_id -> pending_alias
+```
+
+## 4.3 PendingAtomLedger
+
+`PendingAtomLedger` 是未来更可靠的意图日志层，当前阶段不实现。
+
+它用于解决：
+
+- 服务重启后 pending intent 丢失
+- Agent 已收到 pending alias，但后台任务未执行
+- 生成链路需要可观测的状态追踪
+
+Ledger 将在项目未来集中建设事件流与可观测性体系时再加入。当前设计只需避免把 `PendingAtomCache` 与长期审计、事件回放、跨重启恢复等职责绑定。
+
+未来分层可以演进为：
+
+```text
+PendingAtomRegistry
+  -> Runtime PendingAtomCache
+  -> Durable PendingAtomLedger
+```
+
+---
+
+## 5. Alias 策略
+
+Pending alias 必须与正式 memory alias 区分，避免覆盖长期记忆。
+
+建议命名：
+
+```text
+WRITE  -> draft_{slug}_{short_id}
+UPDATE -> rev_{target_alias}_{short_id}
+```
+
+示例：
+
+```text
+draft_login_api_7f3a
+rev_mem_login_api_spec_b921
+```
+
+设计约束：
+
+- pending alias 由系统生成，不允许 Agent 自定义
+- `title` 可参与 slug 生成，但不能直接作为 alias
+- alias 应在当前 runtime 内唯一
+- pending alias 不应覆盖正式 atom alias
+- final alias 生成后，pending alias 至少在当前 run 内保留 redirect
+- 禁止通过 MTP 参数指定 pending alias，以避免 alias 注入、越权覆盖和混淆正式 atom 的风险
+
+---
+
+## 6. 状态机
+
+建议状态：
+
+```text
+PENDING
+  -> MATERIALIZING
+  -> COMMITTED
+  -> MERGED
+  -> UPDATED
+  -> TOUCHED
+  -> REDIRECTED
+  -> DISCARDED
+  -> FAILED
+  -> EXPIRED
+  -> CANCELLED
+```
+
+状态含义：
+
+- `PENDING`: 已创建，可读，后台生成尚未开始
+- `MATERIALIZING`: 帕秋莉正在处理
+- `COMMITTED`: 已生成新的正式 `MemoryAtom`
+- `MERGED`: 生成结果被去重合并到已有 atom
+- `UPDATED`: `UPDATE` 已应用到目标 atom
+- `TOUCHED`: 生成内容与已有 atom 高度重复，仅触达或强化已有 atom
+- `REDIRECTED`: pending alias 已不再持有 pending 内容，只作为指向 canonical alias 的兼容入口
+- `DISCARDED`: 生成链路判定无需物化，例如低价值或完全重复
+- `FAILED`: 生成失败
+- `EXPIRED`: pending 生命周期结束
+- `CANCELLED`: run 取消或系统关闭导致任务终止
+
+---
+
+## 7. 生命周期与 Canonical Alias
+
+PendingAtom 的生命周期需要拆成两层：
+
+```text
+内容生命周期:
+PENDING -> MATERIALIZING -> COMMITTED / MERGED / UPDATED / TOUCHED / DISCARDED / FAILED
+
+寻址兼容生命周期:
+active pending alias -> redirect alias -> expired tombstone
+```
+
+理想情况下，pending 内容在正式记忆落地后即可结束。但 Agent 在读取过 pending alias 后，未必能立即意识到新的正式 alias 已经替代它。因此 pending alias 不应在物化完成后立刻失效，而应进入 redirect grace period。
+
+确定策略：
+
+- 正式记忆生成后，pending alias 不再持有 pending 内容
+- pending alias 退化为轻量 redirect entry
+- redirect entry 指向 canonical alias / canonical uuid
+- 当前 run 内必须保留 redirect，保证旧 pending alias 仍可解析
+- run 结束后可以保留短 TTL tombstone，便于前端、日志和迟到事件查看
+- TTL 后可以清理，但 tombstone 如仍知道 final alias，应尽量返回 final alias 提示
+
+示例：
+
+```text
+draft_login_api_7f3a -> mem_login_api_spec
+```
+
+此时 `draft_login_api_7f3a` 是 deprecated handle，`mem_login_api_spec` 是 canonical alias。
+
+建议 resolver entry：
+
+```python
+class PendingAliasEntry:
+    kind: Literal["pending", "redirect", "tombstone"]
+    pending_alias: str
+    canonical_alias: str | None
+    canonical_uuid: str | None
+    status: PendingAtomStatus
+    expires_at: datetime | None
+```
+
+### 7.1 Redirect 后的访问行为
+
+当 Agent 继续访问旧 pending alias：
+
+```text
+⟪ READ | draft_login_api_7f3a ⟫
+```
+
+系统应自动解析到 canonical alias，并返回正式记忆内容：
+
+```text
+[Alias Redirected]
+Requested alias: draft_login_api_7f3a
+Canonical alias: mem_login_api_spec
+Status: committed
+
+[mem_login_api_spec]:
+...
+
+Action: Use 'mem_login_api_spec' for future READ/RUN/UPDATE calls.
+```
+
+关键要求：
+
+- 渲染主体必须使用正式 alias
+- pending alias 只出现在 redirect header 中
+- 响应中必须明确提示后续使用 canonical alias
+- `SEARCH` 在正式记忆落地后只应返回 canonical alias，不再返回 pending alias
+
+### 7.2 协议层 Canonicalization
+
+不能只依赖 Prompt 让 Agent 自觉切换 alias，必须在协议层做 canonicalization。
+
+规则：
+
+- `READ draft_xxx`: 自动解析到 final atom，返回 canonical alias 提示
+- `RUN draft_xxx`: 如果 canonical atom 是可运行工具，则执行 canonical atom，并提示 alias 已迁移
+- `UPDATE draft_xxx`: 解析到 canonical alias 后，对 canonical atom 创建 revision，并提示后续使用 canonical alias
+- `context_refs=["draft_xxx"]`: 注入 shared context 时自动替换为 canonical alias
+- `SEARCH`: 只暴露 final alias，不暴露已 redirect 的 pending alias
+
+这样即使 Agent 继续使用旧 alias，系统也会持续把它导向正式 alias。
+
+### 7.3 过期 Tombstone
+
+redirect grace period 结束后，pending alias 可以进入 tombstone 或被清理。
+
+如果 tombstone 仍保留 final alias，访问时应返回：
+
+```text
+Temporary alias 'draft_login_api_7f3a' has expired.
+Final alias was: mem_login_api_spec.
+Action: Use 'mem_login_api_spec' for future access.
+```
+
+如果 tombstone 不再知道 final alias，访问时返回：
+
+```text
+Temporary alias 'draft_login_api_7f3a' has expired.
+Action: Use SEARCH to locate the finalized memory.
+```
+
+---
+
+## 8. MTP WRITE 流程
+
+建议流程：
+
+```text
+Agent:
+  ⟪ WRITE | * | title="Login API" content=`...` ⟫
+
+Koakuma:
+  1. 校验 WRITE 权限与参数
+  2. 生成 pending_alias
+  3. 创建 PendingAtom(status=PENDING)
+  4. 写入 PendingAtomCache
+  5. 构造 WriteFocus，附带 pending_alias / intent_id
+  6. 返回 ACK
+```
+
+回填语义应避免暗示正式落库已经完成。推荐文本方向：
+
+```text
+Memory accepted as pending atom 'draft_login_api_7f3a'.
+It is readable during this run. Final memory generation will complete asynchronously.
+```
+
+`WriteFocus` 建议增加：
+
+```python
+pending_alias: str | None
+intent_id: str | None
+```
+
+---
+
+## 9. MTP UPDATE 流程
+
+`UPDATE` 不应直接把目标 alias 伪装成已更新，而应创建 pending revision。
+
+建议流程：
+
+```text
+Agent:
+  ⟪ UPDATE | mem_login_api_spec | instruction="补充刷新 token 逻辑" content=`...` ⟫
+
+Koakuma:
+  1. 解析并校验目标 alias
+  2. 读取目标 atom 当前版本
+  3. 生成 rev_mem_login_api_spec_b921
+  4. 创建 PendingAtom(source_verb=UPDATE, target_alias=...)
+  5. 写入 PendingAtomCache
+  6. 构造 UpdateFocus，附带 pending_alias / intent_id
+  7. 返回 ACK
+```
+
+`READ rev_mem_login_api_spec_b921` 应返回 pending revision 视图。是否让 `READ mem_login_api_spec` 同时展示 pending overlay，需要单独决定。
+
+MVP 建议：
+
+- `READ target_alias` 返回正式旧版本
+- `READ rev_xxx` 返回 pending revision
+- `READ rev_xxx` 不返回旧 atom 主体内容，避免 Agent 误以为旧内容已经完成修改
+- 回填文案明确 pending revision alias
+
+---
+
+## 10. RuntimeAliasResolver 与 READ 解析优先级
+
+后续应引入统一的 `RuntimeAliasResolver` 管理运行时 alias 解析。它负责协调三级缓存命中路径，而不是让 `READ`、`RUN`、`UPDATE` 各自维护分散解析逻辑。
+
+目标解析顺序：
+
+```text
+L0 PendingAtomCache
+  -> L1 KoakumaAtomCache
+  -> L2 storage retrieve_by_aliases
+```
+
+语义：
+
+- L0 负责当前 run 内尚未物化的 pending atom / pending revision
+- L1 负责当前会话中已解析过的正式 `MemoryAtom`
+- L2 负责冷查询长期存储
+- `READ`、`RUN`、`UPDATE` 和 `context_refs` 后续都应通过该 resolver 获取 alias 对应对象、pending 视图或 canonical redirect
+- pending alias 与正式 alias 使用不同命名空间，不允许 L0 覆盖同名正式 atom
+
+`READ pending_alias` 的输出应包含状态：
+
+```text
+[draft_login_api_7f3a]
+status: pending_generation
+source: WRITE
+title: Login API
+
+content:
+...
+
+note: This is a runtime pending atom. Final memory generation is asynchronous.
+```
+
+状态变化后的 READ 行为：
+
+- `PENDING` / `MATERIALIZING`: 返回原始 draft 内容
+- `COMMITTED`: 返回正式 atom 内容，并提示 canonical alias
+- `MERGED`: 返回合并目标 atom，并提示 canonical alias
+- `UPDATED`: 返回更新后的目标 atom，并提示 canonical alias
+- `TOUCHED`: 返回被触达的已有 atom，并提示 canonical alias
+- `REDIRECTED`: 返回 canonical atom 内容，pending alias 只作为 redirect header 出现
+- `DISCARDED`: 返回原始 draft 与未物化原因
+- `FAILED`: 返回原始 draft 与错误原因
+- `EXPIRED`: 返回过期提示；如仍有 canonical alias，应提示使用 canonical alias
+
+---
+
+## 11. Agent Loop 与多次 WRITE/UPDATE 聚合
+
+当前 `ChatResult.write_focus` / `update_focus` 是单值语义。PendingAtom 方案应同步修正为列表语义：
+
+```python
+class ChatResult:
+    write_foci: list[WriteFocus]
+    update_foci: list[UpdateFocus]
+    pending_aliases: list[str]
+```
+
+兼容策略：
+
+- 保留旧字段一段时间，语义为最后一个 focus
+- 新链路优先消费列表字段
+- `InteractionPayload` 同步支持列表化 focus
+
+否则长 run 内多个 `WRITE` / `UPDATE` 仍可能丢失。
+
+---
+
+## 12. 子 Agent Artifact 归属转移
+
+子 Agent 场景是 PendingAtomCache 的核心价值之一。当前阶段不再沿用“harvest alias”的抽象，而是将子 Agent 产生的 pending artifacts 在 `CALL` 结束时显式转移给主 Agent。
+
+建议子 Agent 执行期间：
+
+```text
+Sub-frame starts with pending_artifacts=[]
+
+Sub Agent WRITE
+  -> returns draft_xxx
+  -> frame.pending_artifacts.append(draft_xxx)
+
+Sub-frame ends
+  -> transfer pending artifacts to main frame
+  -> IPC return includes pending aliases
+```
+
+CALL 返回示例：
+
+```text
+<mtp_response status="success" type="ipc_return">
+[Sub-Agent Reply]:
+登录接口逻辑已完成，关键实现已提交为运行时 artifact。
+
+[Artifacts Generated / Pending]:
+- draft_login_api_7f3a (pending, readable now)
+</mtp_response>
+```
+
+主 Agent 继续运行时，可以直接：
+
+```text
+⟪ READ | draft_login_api_7f3a ⟫
+```
+
+可见性规则：
+
+- 子 Agent pending alias 在 `CALL` 结束后返回给主 Agent
+- 在当前多智能体系统阶段下，返回后的 pending atom 视为主 Agent 的运行时资产
+- 主 Agent 可以继续 `READ` 这些 pending alias，并在后续流程中引用它们
+- provenance 必须保留，避免主 Agent 混淆 artifact 来源
+- 兄弟子 Agent 间是否直接传递 pending alias 暂不作为本阶段目标；如需传递，应由主 Agent 显式持有并再分发
+
+---
+
+## 13. 权限与安全
+
+PendingAtom 不能绕过正式记忆权限。
+
+确定规则：
+
+- PendingAtom 创建仍遵循现有 Koakuma MTP 权限流程
+- 没有 `WRITE` 权限的 Agent 不能创建 WRITE pending atom
+- 没有 `UPDATE` 权限的 Agent 不能创建 revision pending atom
+- 没有 `READ` 权限的 Agent 不能读取不可见 pending atom
+- pending atom 继承创建时的 identity 与权限快照
+- 子 Agent artifact 返回主 Agent 后，在当前阶段转为主 Agent 的运行时资产
+- 子 Agent artifact 返回主 Agent 时仍保留 `created_by_agent` / `created_by_frame`
+
+建议 provenance 字段：
+
+```python
+created_by_agent: str
+created_by_frame: str
+permissions_snapshot: dict
+source_command: str
+```
+
+---
+
+## 14. 与 GenerationEngine 的结算协议
+
+后台生成完成后，需要把 pending alias 结算到最终状态。
+
+结算协议必须保留 Deduplicator 的四个原生决策状态：
+
+```text
+CREATE
+UPDATE
+TOUCH
+DISCARD
+```
+
+这些状态不应被简单压扁成 `success` / `failed`，因为它们分别表达了不同的长期记忆语义：
+
+- `CREATE`: draft 被物化为一条新的正式记忆
+- `UPDATE`: draft 与已有记忆发生知识演化合并
+- `TOUCH`: draft 与已有记忆高度重复，仅强化或触达已有记忆
+- `DISCARD`: draft 被判定为不应物化，例如低质量、无价值或不可用
+
+建议模型：
+
+```python
+class PendingAtomSettlement:
+    pending_alias: str
+    intent_id: str
+    status: Literal["COMMITTED", "MERGED", "TOUCHED", "DISCARDED", "FAILED"]
+    duplicate_decision: Literal["CREATE", "UPDATE", "TOUCH", "DISCARD"] | None
+    final_alias: str | None
+    final_uuid: str | None
+    target_alias: str | None
+    target_uuid: str | None
+    canonical_alias: str | None
+    canonical_uuid: str | None
+    message: str
+    error: str | None
+    reason: str | None
+```
+
+### 14.1 Deduplicator 决策映射
+
+`PendingAtomCache` 的 settlement 状态与 Deduplicator 决策建议按以下方式映射：
+
+| Deduplicator 决策 | Pending settlement | canonical 指向 | Agent 说明 |
+| --- | --- | --- | --- |
+| `CREATE` | `COMMITTED` | 新建正式 atom | 已创建新的正式记忆，后续使用新 alias |
+| `UPDATE` | `MERGED` | 被合并更新的已有 atom | 内容已合并到已有记忆，后续使用目标 alias |
+| `TOUCH` | `TOUCHED` | 被触达的已有 atom | 内容与已有记忆重复，未创建新记忆，后续使用已有 alias |
+| `DISCARD` | `DISCARDED` | 无，或可选指向相近 atom | 内容未物化，说明丢弃原因 |
+
+说明：
+
+- `TOUCH` 应作为独立 settlement 保留，而不是并入 `MERGED`
+- `DISCARD` 不应表现为系统错误，它是 generation / dedup 链路的业务决策
+- `FAILED` 只表示系统执行失败，例如 LLM、storage、异常中断等
+- `canonical_alias` 是 Agent 后续应该使用的正式 alias
+- 注意区分 MTP `UPDATE` 指令与 Deduplicator `UPDATE` 决策：前者表示 Agent 请求修改指定记忆，后者表示生成出的 draft 与已有记忆发生知识演化合并
+
+### 14.2 多 Pending Intent 的反向索引
+
+多个 pending intent 理论上可以通过 pending alias / intent id 与正式记忆建立反向索引关系，因为 pending alias 是系统生成且互不相同的。
+
+建议索引关系：
+
+```text
+pending_alias -> intent_id
+intent_id -> generation request item
+generation result item -> intent_id
+intent_id -> settlement
+settlement -> canonical_alias / canonical_uuid
+canonical_uuid -> [pending_alias...]
+```
+
+其中：
+
+- `pending_alias` 是 Agent 可见句柄
+- `intent_id` 是系统内部稳定关联键
+- generation 请求进入引擎时必须携带 `intent_id` / `pending_alias`
+- generation 输出或 dedup 决策必须能回传对应 `intent_id`
+- 同一个正式 atom 可以对应多个 pending alias，例如多个重复 WRITE 最终都 `TOUCH` 同一条记忆
+- 一个 pending alias 只能对应一个 settlement 结果
+
+反向索引用于支持：
+
+- `READ draft_xxx` 时找到 canonical atom
+- 前端展示 `draft_xxx -> mem_xxx`
+- 调试多个 pending intent 被一次 flush 处理后的结算结果
+- 后续事件流中追踪 pending intent 的完整生命周期
+
+### 14.3 结算回填说明
+
+settlement 应包含面向 Agent 的说明信息 `message`。示例：
+
+```text
+CREATE:
+Pending atom 'draft_login_api_7f3a' has been committed as 'mem_login_api_spec'.
+Use 'mem_login_api_spec' for future access.
+
+UPDATE:
+Pending atom 'draft_login_api_7f3a' has been merged into existing memory 'mem_login_api_spec'.
+Use 'mem_login_api_spec' for future access.
+
+TOUCH:
+Pending atom 'draft_login_api_7f3a' duplicated existing memory 'mem_login_api_spec'.
+No new memory was created. Use 'mem_login_api_spec' for future access.
+
+DISCARD:
+Pending atom 'draft_login_api_7f3a' was not materialized.
+Reason: content was too low-value or invalid for long-term memory.
+```
+
+### 14.4 仍需明确的问题
+
+- `GenerationEngine.process()` 如何返回 pending settlement
+- `LibrarianCore._on_generate_memory()` 在完成后由谁调用 registry settle
+- 如果 extraction 阶段从一个 pending intent 中提取出多条 draft，是否允许一个 pending alias 对应多个正式 atom
+
+MVP 可以先做 best-effort settle：
+
+- `WriteFocus.pending_alias` 随 request 进入 generation
+- `intent_id` / `pending_alias` 随 generation request item 进入引擎
+- GenerationEngine 返回 settlement 时保留 `duplicate_decision`
+- 通过 `intent_id -> pending_alias` 反向索引更新 `PendingAtomCache`
+
+---
+
+## 15. Prompt 与 MTP 语义更新
+
+MTP 教学 prompt 需要同步更新，否则 Agent 会误解 pending alias。
+
+建议加入说明：
+
+```text
+WRITE returns a pending alias.
+You may READ the pending alias immediately during the current run.
+Pending aliases are runtime handles, not guaranteed permanent memory aliases.
+After generation completes, the pending alias may redirect to a canonical memory alias.
+When a canonical alias is shown, use it for future READ/RUN/UPDATE calls.
+If you need a stable long-term alias, inspect READ status later or SEARCH after generation.
+```
+
+中文语义：
+
+```text
+WRITE 返回的是运行时 pending alias，不是最终长期记忆 alias。
+你可以在当前 run 内立即 READ 它。
+当后台生成完成后，该 alias 可能结算为正式记忆、合并到已有记忆、被丢弃或失败。
+如果系统返回 canonical alias，后续应使用 canonical alias 进行 READ / RUN / UPDATE。
+```
+
+---
+
+## 16. 可观测性
+
+PendingAtom 横跨 Alice runtime、Koakuma、Librarian、Perception、Generation，必须具备清晰 trace。
+
+建议记录状态迁移：
+
+```text
+created -> pending
+pending -> materializing
+materializing -> committed/merged/updated/touched/discarded/failed
+committed/merged/updated/touched -> redirected
+redirected -> expired
+```
+
+建议日志字段：
+
+```text
+pending_alias
+intent_id
+run_id
+frame_id
+action_id
+source_verb
+status_from
+status_to
+final_alias
+final_uuid
+error
+```
+
+前端 MTPCard 后续可展示：
+
+```text
+WRITE accepted -> draft_xxx pending -> mem_xxx committed
+```
+
+---
+
+## 17. 术语建议
+
+暂定命名：
+
+- `PendingAtom`: 运行时待物化原子
+- `PendingAtomCache`: 内存可读缓存
+- `PendingAtomLedger`: 持久意图日志
+- `PendingAtomRegistry`: 对 cache/ledger 的统一接口
+- `pending_alias`: Agent 可见的运行时 alias
+- `intent_id`: 系统内部写入意图 ID
+- `settlement`: 后台生成结算结果
+- `duplicate_decision`: Deduplicator 的原生决策结果，取值为 `CREATE` / `UPDATE` / `TOUCH` / `DISCARD`
+- `materialization`: pending intent 物化为正式记忆的过程
+- `RuntimeAliasResolver`: 统一 alias 解析层
+- `canonical_alias`: 正式记忆的规范 alias
+- `redirect entry`: pending alias 物化后的兼容寻址入口
+- `tombstone`: redirect grace period 结束后的过期记录
+- `PendingAtomRenderer`: MVP 阶段的 pending atom 简单渲染器，未来由 MemoryCompiler 接管
+
+---
+
+## 18. 实现阶段规划与演进流程
+
+本设计建议按“先打通运行时闭环，再补全结算精度，最后接入事件流与可观测性”的顺序推进。
+
+### 18.1 Phase 1: Runtime MVP
+
+目标：让 Agent 在同一 run 内可以立即读取 `WRITE` / `UPDATE` 产生的 pending alias，并让子 Agent artifacts 能稳定回填给主 Agent。
+
+范围：
+
+1. 新增 `PendingAtom` / `PendingAtomStatus` / `PendingAtomSettlement` 基础模型
+2. 新增内存态 `PendingAtomCache`
+3. 新增 `RuntimeAliasResolver`，抽离三级记忆缓存命中管理逻辑
+4. `WRITE` 创建 `draft_{slug}_{short_id}` pending atom
+5. `UPDATE` 创建 `rev_{target_alias}_{short_id}` pending revision
+6. `READ` 优先解析 L0 `PendingAtomCache`
+7. 原地修改 `ChatResult` / `InteractionPayload` 的 focus 字段，使其支持列表形式
+8. 子 Agent `WRITE` / `UPDATE` 产生的 pending artifact 通过归属转移替代现有 harvest 实现，并在 IPC return 中返回给主 Agent
+9. `context_refs` 读取 pending alias 时能通过 resolver 获取 pending 内容
+10. MTP prompt 更新 pending alias 与 canonical alias 语义
+11. 新增简单 `PendingAtomRenderer`，负责 MVP 阶段的 pending atom 渲染；未来由 MemoryCompiler 接管
+
+验收标准：
+
+- Agent 执行 `WRITE` 后立即 `READ pending_alias` 能读到 draft 内容
+- Agent 执行 `UPDATE` 后立即 `READ rev_alias` 能读到 pending revision 内容
+- 子 Agent 产生的 pending alias 能出现在 `CALL` 返回 payload 中
+- 主 Agent 能读取子 Agent 返回的 pending alias
+- 一轮 run 中多个 `WRITE` / `UPDATE` 不再互相覆盖
+- 权限仍由 Koakuma 原有 MTP 权限流程控制
+- `run_id` 覆盖完整主/子 frame 生命周期
+- `READ rev_xxx` 不返回旧 atom 主体内容
+
+### 18.2 Phase 2: Settlement 与 Canonicalization
+
+目标：让 pending alias 在正式记忆落地后自动指向 canonical alias，并保留 Deduplicator 决策信息。
+
+范围：
+
+1. `GenerationRequest` 携带 `intent_id` / `pending_alias`
+2. `GenerationEngine` 返回 `PendingAtomSettlement`
+3. settlement 保留 `duplicate_decision`
+4. `PendingAtomCache` 根据 settlement 更新状态
+5. pending alias 物化后进入 redirect grace period
+6. `READ` / `RUN` / `UPDATE` / `context_refs` 对 redirect alias 做 canonicalization
+7. `SEARCH` 只暴露 canonical alias，不暴露已 redirect 的 pending alias
+8. `READ redirected_alias` 渲染 canonical atom，并提示后续使用 canonical alias
+
+验收标准：
+
+- `CREATE` 结算后，`READ draft_xxx` 返回新建正式 atom，主体 alias 为 canonical alias
+- `UPDATE` 结算后，`READ draft_xxx` 返回被合并的已有 atom
+- `TOUCH` 结算后，`READ draft_xxx` 返回被触达的已有 atom
+- `DISCARD` 结算后，`READ draft_xxx` 返回未物化说明，不表现为系统错误
+- `RUN` / `UPDATE` 使用 redirect alias 时，会自动操作 canonical atom
+
+### 18.3 Phase 3: Lifecycle 与 GC
+
+目标：明确 run 结束后的 redirect / tombstone 清理策略。
+
+范围：
+
+1. 当前 run 内保留 redirect
+2. run 结束后保留短 TTL tombstone
+3. tombstone 中尽量保留 canonical alias
+4. TTL 后清理 tombstone
+5. cancellation / shutdown 时将未结算 pending atom 标记为 `CANCELLED` 或 `EXPIRED`
+
+验收标准：
+
+- run 内旧 pending alias 始终能 redirect 到 canonical alias
+- run 结束后 tombstone 能给出 final alias 或 SEARCH 指引
+- GC 不会删除仍被当前 frame 栈引用的 pending alias
+
+### 18.4 Phase 4: Event Stream 与 Ledger
+
+目标：在项目统一建设事件流与可观测性时，引入持久化 pending ledger。
+
+范围：
+
+1. 引入 `PendingAtomLedger`
+2. pending 生命周期状态迁移写入事件流
+3. 支持跨进程恢复 pending intent
+4. 支持前端展示完整 pending -> settlement 轨迹
+5. 支持离线调试和 replay
+
+该阶段不属于当前 MVP。
+
+### 18.5 Phase 5: 高级多智能体共享
+
+目标：在多智能体系统进入更复杂拓扑后，扩展 pending alias 的跨 frame 共享策略。
+
+可能方向：
+
+- 主 Agent 显式把已接收的 pending artifact 分发给另一个子 Agent
+- 支持 sibling sub-agent 间通过主 Agent 代理共享 pending alias
+- 引入更细粒度的 pending artifact capability / lease
+- 对不同 Agent 权限快照做更严格的 provenance 检查
+
+该阶段暂不作为当前目标。
+
+---

--- a/docs/mod/PendingAtomCacheDesign.md
+++ b/docs/mod/PendingAtomCacheDesign.md
@@ -104,8 +104,8 @@ HiveMemory 中需要一个 settlement 机制：
 ```text
 pending_alias=draft_login_api_7f3a
 status=COMMITTED
-final_alias=mem_login_api_spec
-final_uuid=...
+canonical_alias=mem_login_api_spec
+canonical_uuid=...
 ```
 
 ---
@@ -135,29 +135,13 @@ class PendingAtom:
     source_verb: Literal["WRITE", "UPDATE"]
     status: PendingAtomStatus
 
-    title: str | None
-    content: str
-    reason: str | None
-    instruction: str | None
-
-    target_alias: str | None
-    target_uuid: str | None
+    focus: WriteFocus | UpdateFocus
 
     identity: Identity
-    run_id: str
-    frame_id: str
-    parent_frame_id: str | None
-    action_id: str | None
-    agent_alias: str | None
-    depth: int
+    runtime_scope: RuntimeScope
 
     created_at: datetime
-    updated_at: datetime
-    expires_at: datetime | None
-
-    final_alias: str | None
-    final_uuid: str | None
-    error: str | None
+    settlement: PendingAtomSettlement | None
 ```
 
 ## 4.2 PendingAtomCache
@@ -176,7 +160,7 @@ class PendingAtom:
 
 ```text
 pending_alias -> PendingAtom
-final_alias -> pending_alias? (optional)
+canonical_uuid -> [pending_alias...] (optional)
 intent_id -> pending_alias
 ```
 
@@ -239,13 +223,14 @@ class WriteFocus:
 class UpdateFocus:
     instruction: str
     content: str | None
-    target_uuid: str
-    target_alias: str
-    existing_memory: MemoryAtom | None
+    base_uuid: str
+    base_alias: str
     identity: Identity
     pending_alias: str | None
     intent_id: str | None
 ```
+
+`existing_memory` 不属于 `UpdateFocus`。它由 LibrarianCore 在进入 Mode C 生成前根据 `base_uuid` 加载，并作为 `GenerationRequest.existing_memory` 注入 GenerationEngine，避免把正式记忆主体混入 pending intent payload。
 
 建议格式：
 
@@ -272,7 +257,7 @@ Pending alias 必须与正式 memory alias 区分，避免覆盖长期记忆。
 
 ```text
 WRITE  -> draft_{slug}_{short_id}
-UPDATE -> rev_{target_alias}_{short_id}
+UPDATE -> rev_{base_alias}_{short_id}
 ```
 
 示例：
@@ -474,7 +459,7 @@ Koakuma:
   1. 解析并校验目标 alias
   2. 读取目标 atom 当前版本
   3. 生成 rev_mem_login_api_spec_b921
-  4. 创建 PendingAtom(source_verb=UPDATE, target_alias=...)
+  4. 创建 PendingAtom(source_verb=UPDATE, focus=UpdateFocus(base_alias=..., base_uuid=...))
   5. 写入 PendingAtomCache
   6. 构造 UpdateFocus，附带 pending_alias / intent_id
   7. 返回 ACK
@@ -484,7 +469,7 @@ Koakuma:
 
 MVP 建议：
 
-- `READ target_alias` 返回正式旧版本
+- `READ base_alias` 返回正式旧版本
 - `READ rev_xxx` 返回 pending revision
 - `READ rev_xxx` 不返回旧 atom 主体内容，避免 Agent 误以为旧内容已经完成修改
 - 回填文案明确 pending revision alias
@@ -508,7 +493,7 @@ L0 PendingAtomCache
 - L0 负责当前 run 内尚未物化的 pending atom / pending revision
 - L1 负责当前会话中已解析过的正式 `MemoryAtom`
 - L2 负责冷查询长期存储
-- `READ`、`RUN`、`UPDATE` 和 `context_refs` 后续都应通过该 resolver 获取 alias 对应对象、pending 视图或 canonical redirect
+- `READ`、`RUN`、`UPDATE` 和 `context_refs` 都应通过该 resolver 获取 alias 对应对象或 pending 视图；其中 `READ`、`RUN`、`context_refs` 在 Phase 2 处理 canonical redirect，`UPDATE redirected_alias` 的 canonicalization 延后到 Phase 3 或 Phase 4
 - pending alias 与正式 alias 使用不同命名空间，不允许 L0 覆盖同名正式 atom
 
 `READ pending_alias` 的输出应包含状态：
@@ -541,20 +526,16 @@ note: This is a runtime pending atom. Final memory generation is asynchronous.
 
 ## 11. Agent Loop 与多次 WRITE/UPDATE 聚合
 
-当前 `ChatResult.write_focus` / `update_focus` 是单值语义。PendingAtom 方案应同步修正为列表语义：
+`ChatResult.write_focus` / `update_focus` 应使用列表语义，但字段名仍保留当前命名：
 
 ```python
 class ChatResult:
-    write_foci: list[WriteFocus]
-    update_foci: list[UpdateFocus]
+    write_focus: list[WriteFocus]
+    update_focus: list[UpdateFocus]
     pending_aliases: list[str]
 ```
 
-兼容策略：
-
-- 保留旧字段一段时间，语义为最后一个 focus
-- 新链路优先消费列表字段
-- `InteractionPayload` 同步支持列表化 focus
+`InteractionPayload` 同步支持列表化 focus。
 
 否则长 run 内多个 `WRITE` / `UPDATE` 仍可能丢失。
 
@@ -657,12 +638,8 @@ DISCARD
 class PendingAtomSettlement:
     pending_alias: str
     intent_id: str
-    status: Literal["COMMITTED", "MERGED", "TOUCHED", "DISCARDED", "FAILED"]
+    status: Literal["COMMITTED", "MERGED", "UPDATED", "TOUCHED", "DISCARDED", "FAILED"]
     duplicate_decision: Literal["CREATE", "UPDATE", "TOUCH", "DISCARD"] | None
-    final_alias: str | None
-    final_uuid: str | None
-    target_alias: str | None
-    target_uuid: str | None
     canonical_alias: str | None
     canonical_uuid: str | None
     message: str
@@ -847,7 +824,7 @@ If you need a stable long-term alias, inspect READ status later or SEARCH after 
 WRITE 返回的是运行时 pending alias，不是最终长期记忆 alias。
 你可以在当前 run 内立即 READ 它。
 当后台生成完成后，该 alias 可能结算为正式记忆、合并到已有记忆、被丢弃或失败。
-如果系统返回 canonical alias，后续应使用 canonical alias 进行 READ / RUN / UPDATE。
+如果系统返回 canonical alias，后续应使用 canonical alias 进行 READ / RUN。`UPDATE redirected_alias` 的 canonicalization 延后到 Phase 3 或 Phase 4 评估实现。
 ```
 
 ---
@@ -877,8 +854,8 @@ action_id
 source_verb
 status_from
 status_to
-final_alias
-final_uuid
+canonical_alias
+canonical_uuid
 error
 ```
 
@@ -925,7 +902,7 @@ WRITE accepted -> draft_xxx pending -> mem_xxx committed
 2. 新增内存态 `PendingAtomCache`
 3. 新增 `RuntimeAliasResolver`，抽离三级记忆缓存命中管理逻辑
 4. `WRITE` 创建 `draft_{slug}_{short_id}` pending atom
-5. `UPDATE` 创建 `rev_{target_alias}_{short_id}` pending revision
+5. `UPDATE` 创建 `rev_{base_alias}_{short_id}` pending revision
 6. `READ` 优先解析 L0 `PendingAtomCache`
 7. 原地修改 `ChatResult` / `InteractionPayload` 的 focus 字段，使其支持列表形式
 8. 子 Agent `WRITE` / `UPDATE` 产生的 pending artifact 通过归属转移替代现有 harvest 实现，并在 IPC return 中返回给主 Agent
@@ -957,7 +934,7 @@ WRITE accepted -> draft_xxx pending -> mem_xxx committed
 5. `AliceRuntime` 订阅 settlement event，并调用 `PendingAtomCache.apply_settlement()`
 6. `PendingAtomCache` 根据 settlement 更新状态
 7. pending alias 物化后进入 redirect grace period
-8. `READ` / `RUN` / `UPDATE` / `context_refs` 对 redirect alias 做 canonicalization
+8. `READ` / `RUN` / `context_refs` 对 redirect alias 做 canonicalization
 9. `SEARCH` 只暴露 canonical alias，不暴露已 redirect 的 pending alias
 10. `READ redirected_alias` 渲染 canonical atom，并提示后续使用 canonical alias
 
@@ -967,7 +944,8 @@ WRITE accepted -> draft_xxx pending -> mem_xxx committed
 - `UPDATE` 结算后，`READ draft_xxx` 返回被合并的已有 atom
 - `TOUCH` 结算后，`READ draft_xxx` 返回被触达的已有 atom
 - `DISCARD` 结算后，`READ draft_xxx` 返回未物化说明，不表现为系统错误
-- `RUN` / `UPDATE` 使用 redirect alias 时，会自动操作 canonical atom
+- `RUN` 使用 redirect alias 时，会自动操作 canonical atom
+- `context_refs` 使用 redirect alias 时，会向子 Agent 注入 canonical atom 内容
 
 ### 18.3 Phase 3: Lifecycle 与 GC
 
@@ -980,12 +958,14 @@ WRITE accepted -> draft_xxx pending -> mem_xxx committed
 3. tombstone 中尽量保留 canonical alias
 4. TTL 后清理 tombstone
 5. cancellation / shutdown 时将未结算 pending atom 标记为 `CANCELLED` 或 `EXPIRED`
+6. 评估并实现 `UPDATE redirected_alias` 的 canonicalization 语义
 
 验收标准：
 
 - run 内旧 pending alias 始终能 redirect 到 canonical alias
 - run 结束后 tombstone 能给出 final alias 或 SEARCH 指引
 - GC 不会删除仍被当前 frame 栈引用的 pending alias
+- 如启用 `UPDATE redirected_alias` canonicalization，必须确保 ACK、revision pending alias 和 L1 cache invalidation 都指向 canonical atom
 
 ### 18.4 Phase 4: Event Stream 与 Ledger
 

--- a/src/hivememory/alice/runtime/agent/frame_scheduler.py
+++ b/src/hivememory/alice/runtime/agent/frame_scheduler.py
@@ -7,6 +7,7 @@ Phase 2 多智能体子代理调用的核心调度组件。
 
 import logging
 from typing import TYPE_CHECKING, List, Optional
+from uuid import uuid4
 
 from hivememory.core.models import AgentProfile, Identity
 from hivememory.alice.runtime.models import ExecutionFrame
@@ -55,6 +56,7 @@ class FrameScheduler:
         主帧从感知层 TopicBuffer 装载，执行后卸载回 MMU。
         """
         self._frame_counter += 1
+        run_id = f"run_{uuid4().hex}"
         frame = ExecutionFrame(
             process_id=f"pid_main_{self._frame_counter}",
             agent_profile=agent_profile,
@@ -62,6 +64,7 @@ class FrameScheduler:
             depth=0,
             topic_id=topic_id,
             identity=identity,
+            run_id=run_id,
         )
         logger.debug(f"Created main frame: {frame}")
         return frame
@@ -100,6 +103,7 @@ class FrameScheduler:
             working_history=working_history,
             depth=1,
             topic_id=None,
+            run_id=parent_frame.run_id,
             parent_frame_id=parent_frame.process_id,
             identity=parent_frame.identity,
         )

--- a/src/hivememory/alice/runtime/agent/frame_scheduler.py
+++ b/src/hivememory/alice/runtime/agent/frame_scheduler.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, List, Optional
 from uuid import uuid4
 
 from hivememory.core.models import AgentProfile, Identity
-from hivememory.alice.runtime.models import ExecutionFrame
+from hivememory.alice.runtime.models import ExecutionFrame, RuntimeScope
 
 if TYPE_CHECKING:
     from hivememory.prompts.assembler import AgentPromptAssembler
@@ -57,14 +57,17 @@ class FrameScheduler:
         """
         self._frame_counter += 1
         run_id = f"run_{uuid4().hex}"
+        frame_id = f"frame_main_{self._frame_counter}"
         frame = ExecutionFrame(
-            process_id=f"pid_main_{self._frame_counter}",
+            runtime_scope=RuntimeScope(
+                run_id=run_id,
+                frame_id=frame_id,
+                depth=0,
+            ),
             agent_profile=agent_profile,
             working_history=messages,
-            depth=0,
             topic_id=topic_id,
             identity=identity,
-            run_id=run_id,
         )
         logger.debug(f"Created main frame: {frame}")
         return frame
@@ -97,14 +100,12 @@ class FrameScheduler:
         )
 
         self._frame_counter += 1
+        frame_id = f"frame_sub_{self._frame_counter}"
         sub_frame = ExecutionFrame(
-            process_id=f"pid_sub_{self._frame_counter}",
+            runtime_scope=parent_frame.runtime_scope.for_child(frame_id),
             agent_profile=agent_profile,
             working_history=working_history,
-            depth=1,
             topic_id=None,
-            run_id=parent_frame.run_id,
-            parent_frame_id=parent_frame.process_id,
             identity=parent_frame.identity,
         )
 
@@ -115,7 +116,7 @@ class FrameScheduler:
         """挂起当前帧（压栈）。"""
         self._frame_stack.append(frame)
         logger.debug(
-            f"Suspended frame: {frame.process_id}, stack_depth={len(self._frame_stack)}"
+            f"Suspended frame: {frame.runtime_scope.frame_id}, stack_depth={len(self._frame_stack)}"
         )
 
     def resume_frame(self) -> Optional[ExecutionFrame]:
@@ -123,7 +124,7 @@ class FrameScheduler:
         if self._frame_stack:
             frame = self._frame_stack.pop()
             logger.debug(
-                f"Resumed frame: {frame.process_id}, stack_depth={len(self._frame_stack)}"
+                f"Resumed frame: {frame.runtime_scope.frame_id}, stack_depth={len(self._frame_stack)}"
             )
             return frame
         logger.warning("Attempted to resume frame but stack is empty")

--- a/src/hivememory/alice/runtime/agent/loop_executor.py
+++ b/src/hivememory/alice/runtime/agent/loop_executor.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Kernel Loop Executor - 帧栈驱动的递归生成循环执行器
 
 职责：
@@ -24,10 +24,10 @@ from typing import List, Optional, Dict, Any, TYPE_CHECKING, Callable, Awaitable
 
 from hivememory.core.protocol.models import ChatResult
 from hivememory.alice.runtime.models import ExecutionFrame, MTPExecutionContext
+from hivememory.alice.runtime.pending_renderer import PendingAtomRenderer
 from hivememory.core.mtp.models import MTPVerb
 from hivememory.core.models import TurnEvent
 from hivememory.system.config import AgentRuntimeConfig
-from hivememory.system.contracts.routes import GlobalRoutes
 
 if TYPE_CHECKING:
     from hivememory.alice.runtime.bus import AliceBus
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from hivememory.alice.runtime.agent.mtp_executor import MTPExecutor
     from hivememory.alice.runtime.agent.profile_resolver import AgentProfileResolver
     from hivememory.alice.runtime.agent.worker_agent import WorkerAgentService
+    from hivememory.alice.runtime.resolver import RuntimeAliasResolver
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,7 @@ class KernelLoopExecutor:
         agent_profile_resolver: "AgentProfileResolver",
         mtp_executor: "MTPExecutor",
         config: AgentRuntimeConfig,
+        alias_resolver: "RuntimeAliasResolver",
     ):
         self.worker_agent = worker_agent
         self._frame_scheduler = frame_scheduler
@@ -65,6 +67,7 @@ class KernelLoopExecutor:
         self._agent_profile_resolver = agent_profile_resolver
         self._mtp_executor = mtp_executor
         self.config = config
+        self._alias_resolver = alias_resolver
 
     def _namespace_for_frame(self, frame: ExecutionFrame) -> Dict[str, Any]:
         """构造事件命名空间元数据。"""
@@ -194,8 +197,9 @@ class KernelLoopExecutor:
         """
         text_segments: List[str] = []
         turn_events: List[TurnEvent] = []
-        write_focus: Optional[Any] = None
-        update_focus: Optional[Any] = None
+        write_foci: List[Any] = []
+        update_foci: List[Any] = []
+        pending_aliases: List[str] = []
         _seq = 0
         iteration = 0
 
@@ -272,9 +276,11 @@ class KernelLoopExecutor:
             )
             if mtp_result is not None:
                 if mtp_result.write_focus is not None:
-                    write_focus = mtp_result.write_focus
+                    write_foci.append(mtp_result.write_focus)
                 if mtp_result.update_focus is not None:
-                    update_focus = mtp_result.update_focus
+                    update_foci.append(mtp_result.update_focus)
+                if mtp_result.pending_alias is not None:
+                    pending_aliases.append(mtp_result.pending_alias)
             if mtp_result is not None and mtp_result.command:
                 verb_hint = mtp_result.command.verb.value
                 target_hint, args_hint, raw_hint = self._extract_command_info(
@@ -373,10 +379,8 @@ class KernelLoopExecutor:
                     iteration=iteration,
                 )
                 if sub_result is not None:
-                    if sub_result.write_focus is not None:
-                        write_focus = sub_result.write_focus
-                    if sub_result.update_focus is not None:
-                        update_focus = sub_result.update_focus
+                    write_foci.extend(sub_result.write_focus)
+                    update_foci.extend(sub_result.update_focus)
                 if stream_emitter is not None and stream_events:
                     for event in stream_events:
                         await stream_emitter(event)
@@ -450,8 +454,9 @@ class KernelLoopExecutor:
             mtp_iterations=max(0, iteration - 1),
             total_iterations=iteration,
             turn_events=turn_events,
-            write_focus=write_focus,
-            update_focus=update_focus,
+            write_focus=write_foci,
+            update_focus=update_foci,
+            pending_aliases=pending_aliases,
         )
         if stream_emitter is not None:
             await stream_emitter({"event": "done", "data": loop_result.model_dump()})
@@ -652,6 +657,7 @@ class KernelLoopExecutor:
                 None,
             )
 
+    # TODO: 由MemoryCompiler统一接管渲染/编译逻辑
     async def _fetch_context_refs_content(
         self,
         aliases: List[str],
@@ -660,22 +666,27 @@ class KernelLoopExecutor:
         if not aliases:
             return ""
 
-        try:
-            result = await self._local_bus.request(
-                GlobalRoutes.PATCHOULI_MEMORY_RETRIEVE_BY_ALIASES,
-                aliases,
-                identity,
-            )
-        except Exception as e:
-            logger.warning(f"Failed to fetch context_refs {aliases}: {e}")
-            return ""
+        parts: List[str] = []
+        context = MTPExecutionContext(identity=identity)
+        for alias in aliases:
+            try:
+                resolved = await self._alias_resolver.resolve(alias, context=context)
+            except Exception as e:
+                logger.warning(f"Failed to resolve context_ref {alias}: {e}")
+                continue
 
-        rendered_context = getattr(result, "rendered_context", "") or ""
-        if not rendered_context:
+            if resolved.kind == "pending" and resolved.pending is not None:
+                parts.append(PendingAtomRenderer.render_read(resolved.pending))
+            elif resolved.kind == "atom" and resolved.atom is not None:
+                parts.append(f"[{alias}]:\n{resolved.atom.payload.content}")
+            else:
+                logger.warning(f"Context ref alias not found: {alias}")
+
+        if not parts:
             logger.warning(f"No rendered context returned for context_refs: {aliases}")
             return ""
 
-        return f"[Shared Context from Parent Agent]\n\n{rendered_context}"
+        return f"[Shared Context from Parent Agent]\n\n" + "\n\n".join(parts)
 
     def _assemble_ipc_return(
         self,
@@ -702,7 +713,10 @@ class KernelLoopExecutor:
             lines.append("")
             lines.append("[Artifacts Generated / Updated]:")
             for alias in harvested_aliases:
-                lines.append(f"- {alias}")
+                if alias.startswith("draft_") or alias.startswith("rev_"):
+                    lines.append(f"- {alias} (pending, readable now)")
+                else:
+                    lines.append(f"- {alias}")
 
         lines.append("</mtp_response>")
         return "\n".join(lines)
@@ -726,16 +740,16 @@ class KernelLoopExecutor:
             return
 
         if verb == MTPVerb.UPDATE:
-            alias = mtp_result.command.target.single_alias
+            alias = mtp_result.pending_alias or mtp_result.command.target.single_alias
             if alias:
                 frame.add_harvested_alias(alias)
                 logger.debug(f"Harvested UPDATE alias: {alias}")
 
         elif verb == MTPVerb.WRITE:
-            alias = None
+            alias = mtp_result.pending_alias
             if alias:
                 frame.add_harvested_alias(alias)
-                logger.debug(f"Harvested WRITE alias: {alias}")
+                logger.debug(f"Harvested WRITE pending alias: {alias}")
 
 
 __all__ = ["KernelLoopExecutor"]

--- a/src/hivememory/alice/runtime/agent/loop_executor.py
+++ b/src/hivememory/alice/runtime/agent/loop_executor.py
@@ -677,6 +677,9 @@ class KernelLoopExecutor:
 
             if resolved.kind == "pending" and resolved.pending is not None:
                 parts.append(PendingAtomRenderer.render_read(resolved.pending))
+            elif resolved.kind == "redirect" and resolved.atom is not None:
+                canonical_alias = resolved.canonical_alias or resolved.atom.get_alias()
+                parts.append(f"[{canonical_alias}]:\n{resolved.atom.payload.content}")
             elif resolved.kind == "atom" and resolved.atom is not None:
                 parts.append(f"[{alias}]:\n{resolved.atom.payload.content}")
             else:

--- a/src/hivememory/alice/runtime/agent/loop_executor.py
+++ b/src/hivememory/alice/runtime/agent/loop_executor.py
@@ -268,6 +268,8 @@ class KernelLoopExecutor:
             mtp_context = MTPExecutionContext(
                 identity=frame.identity,
                 agent_profile=frame.agent_profile,
+                run_id=frame.run_id,
+                frame_id=frame.process_id,
                 depth=frame.depth,
             )
             mtp_result = await self._mtp_executor.intercept_and_execute(

--- a/src/hivememory/alice/runtime/agent/loop_executor.py
+++ b/src/hivememory/alice/runtime/agent/loop_executor.py
@@ -76,9 +76,9 @@ class KernelLoopExecutor:
         agent_id = getattr(frame.agent_profile, "alias", None) or frame.identity.agent_id
         return {
             "scope": "sub" if frame.is_sub_frame() else "main",
-            "depth": frame.depth,
+            "depth": frame.runtime_scope.depth,
             "agent_id": agent_id,
-            "frame_id": frame.process_id,
+            "frame_id": frame.runtime_scope.frame_id,
         }
 
     async def execute_main_frame(
@@ -265,12 +265,11 @@ class KernelLoopExecutor:
             target_hint = ""
             args_hint: Dict[str, Any] = {}
 
+            action_id = f"action_{iteration}_{_seq}"
             mtp_context = MTPExecutionContext(
                 identity=frame.identity,
                 agent_profile=frame.agent_profile,
-                run_id=frame.run_id,
-                frame_id=frame.process_id,
-                depth=frame.depth,
+                runtime_scope=frame.runtime_scope.with_action(action_id),
             )
             mtp_result = await self._mtp_executor.intercept_and_execute(
                 result.text,
@@ -288,7 +287,6 @@ class KernelLoopExecutor:
                 target_hint, args_hint, raw_hint = self._extract_command_info(
                     mtp_result.command, raw_hint
                 )
-            action_id = f"action_{iteration}_{_seq}"
             command_event = TurnEvent(
                 kind="tool_call",
                 sequence=_seq,
@@ -571,7 +569,7 @@ class KernelLoopExecutor:
                 "task": task,
                 "iteration": iteration,
                 "scope": "sub",
-                "depth": frame.depth + 1,
+                "depth": frame.runtime_scope.depth + 1,
                 "frame_id": None,
             }
             stream_events.append({"event": "sub_agent_start", "data": sub_start_data})
@@ -620,8 +618,8 @@ class KernelLoopExecutor:
                     "final_text": sub_result.final_text,
                     "iteration": iteration,
                     "scope": "sub",
-                    "depth": frame.depth + 1,
-                    "frame_id": sub_frame.process_id,
+                    "depth": frame.runtime_scope.depth + 1,
+                    "frame_id": sub_frame.runtime_scope.frame_id,
                     "agent_id": target_alias,
                 }
                 stream_events.append({"event": "sub_agent_end", "data": sub_end_data})
@@ -644,7 +642,7 @@ class KernelLoopExecutor:
                     "status": "error",
                     "iteration": iteration,
                     "scope": "sub",
-                    "depth": frame.depth + 1,
+                    "depth": frame.runtime_scope.depth + 1,
                     "frame_id": None,
                     "agent_id": target_alias,
                 }

--- a/src/hivememory/alice/runtime/agent/runtime.py
+++ b/src/hivememory/alice/runtime/agent/runtime.py
@@ -14,6 +14,7 @@ from hivememory.alice.runtime.agent.frame_scheduler import FrameScheduler
 if TYPE_CHECKING:
     from hivememory.alice.runtime.bus import AliceBus
     from hivememory.alice.runtime.agent.mtp_executor import MTPExecutor
+    from hivememory.alice.runtime.resolver import RuntimeAliasResolver
     from hivememory.prompts.assembler import AgentPromptAssembler
     from hivememory.system.config import HiveMemoryConfig
 
@@ -30,9 +31,10 @@ class AgentRuntime:
         prompt_assembler: "AgentPromptAssembler",
         mtp_executor: "MTPExecutor",
         config: "HiveMemoryConfig",
+        alias_resolver: "RuntimeAliasResolver",
     ) -> None:
         self._agent_profile_resolver = AgentProfileResolver(local_bus=local_bus)
-        
+
         self._frame_scheduler = FrameScheduler(
             prompt_assembler=prompt_assembler,
         )
@@ -45,6 +47,7 @@ class AgentRuntime:
             agent_profile_resolver=self._agent_profile_resolver,
             mtp_executor=self._mtp_executor,
             config=config.agent_runtime,
+            alias_resolver=alias_resolver,
         )
 
     async def get_agent_profile(self, agent_alias: str) -> AgentProfile:

--- a/src/hivememory/alice/runtime/cache.py
+++ b/src/hivememory/alice/runtime/cache.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 
 from hivememory.alice.runtime.models import PendingAtom, PendingAtomStatus, RuntimeScope
 from hivememory.core.models import AgentProfile, Identity, MemoryAtom, MemoryType
-from hivememory.engines.generation.models import UpdateFocus, WriteFocus
+from hivememory.engines.generation.models import PendingAtomSettlement, UpdateFocus, WriteFocus
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +44,8 @@ class PendingAtomCache:
     def __init__(self) -> None:
         self._atoms: Dict[str, PendingAtom] = {}
         self._intent_index: Dict[str, str] = {}
+        self._redirects: Dict[str, PendingAtomSettlement] = {}
+        self._canonical_index: Dict[str, List[str]] = {}
 
     def register_write(
         self,
@@ -121,7 +123,7 @@ class PendingAtomCache:
         logger.debug(f"Registered pending UPDATE: {pending_alias} (intent={intent_id})")
         return atom
 
-    def apply_settlement(self, settlement) -> None:
+    def apply_settlement(self, settlement: PendingAtomSettlement) -> None:
         """
         Apply a settlement from the generation pipeline to update pending atom state.
 
@@ -156,6 +158,15 @@ class PendingAtomCache:
             atom.status = new_status
 
         atom.settlement = settlement
+        if settlement.canonical_alias or settlement.canonical_uuid:
+            self._redirects[atom.pending_alias] = settlement
+            if settlement.canonical_uuid:
+                aliases = self._canonical_index.setdefault(
+                    settlement.canonical_uuid,
+                    [],
+                )
+                if atom.pending_alias not in aliases:
+                    aliases.append(atom.pending_alias)
 
         logger.debug(
             f"Settlement applied to '{atom.pending_alias}': "
@@ -173,6 +184,14 @@ class PendingAtomCache:
             return self._atoms.get(pending_alias)
         return None
 
+    def get_redirect(self, pending_alias: str) -> Optional[PendingAtomSettlement]:
+        """返回 pending alias 对应的 canonical redirect settlement。"""
+        return self._redirects.get(pending_alias)
+
+    def get_pending_aliases_for_canonical_uuid(self, canonical_uuid: str) -> List[str]:
+        """返回指向同一 canonical UUID 的 pending alias 列表。"""
+        return list(self._canonical_index.get(canonical_uuid, []))
+
     def has(self, alias: str) -> bool:
         """检查 alias 是否为已注册的 pending atom。"""
         return alias in self._atoms
@@ -189,6 +208,8 @@ class PendingAtomCache:
         """清空全部 pending atom。"""
         self._atoms.clear()
         self._intent_index.clear()
+        self._redirects.clear()
+        self._canonical_index.clear()
 
     @property
     def size(self) -> int:

--- a/src/hivememory/alice/runtime/cache.py
+++ b/src/hivememory/alice/runtime/cache.py
@@ -49,6 +49,7 @@ class PendingAtomCache:
         title: Optional[str],
         reason: Optional[str],
         identity: Identity,
+        run_id: str = "",
         frame_id: str = "",
         depth: int = 0,
     ) -> PendingAtom:
@@ -68,6 +69,7 @@ class PendingAtomCache:
             title=title,
             reason=reason,
             identity=identity,
+            run_id=run_id,
             frame_id=frame_id,
             depth=depth,
         )
@@ -82,6 +84,7 @@ class PendingAtomCache:
         instruction: str,
         content: Optional[str],
         identity: Identity,
+        run_id: str = "",
         frame_id: str = "",
         depth: int = 0,
     ) -> PendingAtom:
@@ -98,6 +101,7 @@ class PendingAtomCache:
             target_alias=target_alias,
             target_uuid=target_uuid,
             identity=identity,
+            run_id=run_id,
             frame_id=frame_id,
             depth=depth,
         )

--- a/src/hivememory/alice/runtime/cache.py
+++ b/src/hivememory/alice/runtime/cache.py
@@ -17,7 +17,7 @@ from collections import OrderedDict
 from typing import Dict, List, Optional
 from uuid import uuid4
 
-from hivememory.alice.runtime.models import PendingAtom, PendingAtomStatus
+from hivememory.alice.runtime.models import PendingAtom, PendingAtomStatus, RuntimeScope
 from hivememory.core.models import AgentProfile, Identity, MemoryAtom, MemoryType
 
 logger = logging.getLogger(__name__)
@@ -49,9 +49,7 @@ class PendingAtomCache:
         title: Optional[str],
         reason: Optional[str],
         identity: Identity,
-        run_id: str = "",
-        frame_id: str = "",
-        depth: int = 0,
+        runtime_scope: Optional[RuntimeScope] = None,
     ) -> PendingAtom:
         """注册 WRITE pending atom，返回带有生成 alias 的 PendingAtom。"""
         slug_source = title if title else content[:20]
@@ -69,9 +67,7 @@ class PendingAtomCache:
             title=title,
             reason=reason,
             identity=identity,
-            run_id=run_id,
-            frame_id=frame_id,
-            depth=depth,
+            runtime_scope=runtime_scope or RuntimeScope(),
         )
         self._atoms[pending_alias] = atom
         logger.debug(f"Registered pending WRITE: {pending_alias}")
@@ -84,9 +80,7 @@ class PendingAtomCache:
         instruction: str,
         content: Optional[str],
         identity: Identity,
-        run_id: str = "",
-        frame_id: str = "",
-        depth: int = 0,
+        runtime_scope: Optional[RuntimeScope] = None,
     ) -> PendingAtom:
         """注册 UPDATE pending revision，返回带有生成 alias 的 PendingAtom。"""
         short_id = uuid4().hex[:4]
@@ -101,9 +95,7 @@ class PendingAtomCache:
             target_alias=target_alias,
             target_uuid=target_uuid,
             identity=identity,
-            run_id=run_id,
-            frame_id=frame_id,
-            depth=depth,
+            runtime_scope=runtime_scope or RuntimeScope(),
         )
         self._atoms[pending_alias] = atom
         logger.debug(f"Registered pending UPDATE: {pending_alias}")

--- a/src/hivememory/alice/runtime/cache.py
+++ b/src/hivememory/alice/runtime/cache.py
@@ -12,12 +12,123 @@ Kernel Runtime 缓存实现。
 """
 
 import logging
+import re
 from collections import OrderedDict
 from typing import Dict, List, Optional
+from uuid import uuid4
 
-from hivememory.core.models import AgentProfile, MemoryAtom, MemoryType
+from hivememory.alice.runtime.models import PendingAtom, PendingAtomStatus
+from hivememory.core.models import AgentProfile, Identity, MemoryAtom, MemoryType
 
 logger = logging.getLogger(__name__)
+
+
+def _slugify(text: str, max_len: int = 30) -> str:
+    """将文本转为 alias 友好的 slug 片段。"""
+    slug = text.lower().strip()
+    slug = re.sub(r"[^a-z0-9\s_]", "", slug)
+    slug = re.sub(r"\s+", "_", slug)
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return slug[:max_len].rstrip("_")
+
+
+class PendingAtomCache:
+    """
+    L0 运行时 pending atom 缓存。
+
+    作为 Alice runtime 共享基础设施，主帧和子帧共享同一实例。
+    子帧 WRITE 后主帧自动可见，无需 merge。
+    """
+
+    def __init__(self) -> None:
+        self._atoms: Dict[str, PendingAtom] = {}
+
+    def register_write(
+        self,
+        content: str,
+        title: Optional[str],
+        reason: Optional[str],
+        identity: Identity,
+        frame_id: str = "",
+        depth: int = 0,
+    ) -> PendingAtom:
+        """注册 WRITE pending atom，返回带有生成 alias 的 PendingAtom。"""
+        slug_source = title if title else content[:20]
+        slug = _slugify(slug_source)
+        if not slug:
+            slug = "untitled"
+        short_id = uuid4().hex[:4]
+        pending_alias = f"draft_{slug}_{short_id}"
+
+        atom = PendingAtom(
+            pending_alias=pending_alias,
+            status=PendingAtomStatus.PENDING,
+            source_verb="WRITE",
+            content=content,
+            title=title,
+            reason=reason,
+            identity=identity,
+            frame_id=frame_id,
+            depth=depth,
+        )
+        self._atoms[pending_alias] = atom
+        logger.debug(f"Registered pending WRITE: {pending_alias}")
+        return atom
+
+    def register_update(
+        self,
+        target_alias: str,
+        target_uuid: str,
+        instruction: str,
+        content: Optional[str],
+        identity: Identity,
+        frame_id: str = "",
+        depth: int = 0,
+    ) -> PendingAtom:
+        """注册 UPDATE pending revision，返回带有生成 alias 的 PendingAtom。"""
+        short_id = uuid4().hex[:4]
+        pending_alias = f"rev_{target_alias}_{short_id}"
+
+        atom = PendingAtom(
+            pending_alias=pending_alias,
+            status=PendingAtomStatus.REVISION,
+            source_verb="UPDATE",
+            content=content or "",
+            instruction=instruction,
+            target_alias=target_alias,
+            target_uuid=target_uuid,
+            identity=identity,
+            frame_id=frame_id,
+            depth=depth,
+        )
+        self._atoms[pending_alias] = atom
+        logger.debug(f"Registered pending UPDATE: {pending_alias}")
+        return atom
+
+    def get(self, pending_alias: str) -> Optional[PendingAtom]:
+        """通过 pending alias 查询。"""
+        return self._atoms.get(pending_alias)
+
+    def has(self, alias: str) -> bool:
+        """检查 alias 是否为已注册的 pending atom。"""
+        return alias in self._atoms
+
+    def all_aliases(self) -> List[str]:
+        """返回所有已注册的 pending alias。"""
+        return list(self._atoms.keys())
+
+    def all_atoms(self) -> List[PendingAtom]:
+        """返回所有已注册的 PendingAtom。"""
+        return list(self._atoms.values())
+
+    def clear(self) -> None:
+        """清空全部 pending atom。"""
+        self._atoms.clear()
+
+    @property
+    def size(self) -> int:
+        """当前缓存的 pending atom 数量。"""
+        return len(self._atoms)
 
 
 class KoakumaAtomCache:

--- a/src/hivememory/alice/runtime/cache.py
+++ b/src/hivememory/alice/runtime/cache.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from hivememory.alice.runtime.models import PendingAtom, PendingAtomStatus, RuntimeScope
 from hivememory.core.models import AgentProfile, Identity, MemoryAtom, MemoryType
+from hivememory.engines.generation.models import UpdateFocus, WriteFocus
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ class PendingAtomCache:
 
     def __init__(self) -> None:
         self._atoms: Dict[str, PendingAtom] = {}
+        self._intent_index: Dict[str, str] = {}
 
     def register_write(
         self,
@@ -58,25 +60,34 @@ class PendingAtomCache:
             slug = "untitled"
         short_id = uuid4().hex[:4]
         pending_alias = f"draft_{slug}_{short_id}"
+        intent_id = f"intent_{uuid4().hex[:12]}"
+        focus = WriteFocus(
+            content=content,
+            reason=reason,
+            title=title,
+            identity=identity,
+            pending_alias=pending_alias,
+            intent_id=intent_id,
+        )
 
         atom = PendingAtom(
             pending_alias=pending_alias,
+            intent_id=intent_id,
             status=PendingAtomStatus.PENDING,
             source_verb="WRITE",
-            content=content,
-            title=title,
-            reason=reason,
+            focus=focus,
             identity=identity,
             runtime_scope=runtime_scope or RuntimeScope(),
         )
         self._atoms[pending_alias] = atom
-        logger.debug(f"Registered pending WRITE: {pending_alias}")
+        self._intent_index[intent_id] = pending_alias
+        logger.debug(f"Registered pending WRITE: {pending_alias} (intent={intent_id})")
         return atom
 
     def register_update(
         self,
-        target_alias: str,
-        target_uuid: str,
+        base_alias: str,
+        base_uuid: str,
         instruction: str,
         content: Optional[str],
         identity: Identity,
@@ -84,26 +95,83 @@ class PendingAtomCache:
     ) -> PendingAtom:
         """注册 UPDATE pending revision，返回带有生成 alias 的 PendingAtom。"""
         short_id = uuid4().hex[:4]
-        pending_alias = f"rev_{target_alias}_{short_id}"
+        pending_alias = f"rev_{base_alias}_{short_id}"
+        intent_id = f"intent_{uuid4().hex[:12]}"
+        focus = UpdateFocus(
+            instruction=instruction,
+            content=content or None,
+            base_alias=base_alias,
+            base_uuid=base_uuid,
+            identity=identity,
+            pending_alias=pending_alias,
+            intent_id=intent_id,
+        )
 
         atom = PendingAtom(
             pending_alias=pending_alias,
+            intent_id=intent_id,
             status=PendingAtomStatus.REVISION,
             source_verb="UPDATE",
-            content=content or "",
-            instruction=instruction,
-            target_alias=target_alias,
-            target_uuid=target_uuid,
+            focus=focus,
             identity=identity,
             runtime_scope=runtime_scope or RuntimeScope(),
         )
         self._atoms[pending_alias] = atom
-        logger.debug(f"Registered pending UPDATE: {pending_alias}")
+        self._intent_index[intent_id] = pending_alias
+        logger.debug(f"Registered pending UPDATE: {pending_alias} (intent={intent_id})")
         return atom
+
+    def apply_settlement(self, settlement) -> None:
+        """
+        Apply a settlement from the generation pipeline to update pending atom state.
+
+        Args:
+            settlement: PendingAtomSettlement instance
+        """
+        pending_alias = settlement.pending_alias
+        atom = self._atoms.get(pending_alias)
+
+        if atom is None and settlement.intent_id:
+            resolved_alias = self._intent_index.get(settlement.intent_id)
+            if resolved_alias:
+                atom = self._atoms.get(resolved_alias)
+
+        if atom is None:
+            logger.warning(
+                f"Settlement for unknown pending atom: "
+                f"alias={settlement.pending_alias}, intent={settlement.intent_id}"
+            )
+            return
+
+        status_map = {
+            "COMMITTED": PendingAtomStatus.COMMITTED,
+            "MERGED": PendingAtomStatus.MERGED,
+            "UPDATED": PendingAtomStatus.UPDATED,
+            "TOUCHED": PendingAtomStatus.TOUCHED,
+            "DISCARDED": PendingAtomStatus.DISCARDED,
+            "FAILED": PendingAtomStatus.FAILED,
+        }
+        new_status = status_map.get(settlement.status)
+        if new_status:
+            atom.status = new_status
+
+        atom.settlement = settlement
+
+        logger.debug(
+            f"Settlement applied to '{atom.pending_alias}': "
+            f"status={atom.status.value}, canonical={settlement.canonical_alias}"
+        )
 
     def get(self, pending_alias: str) -> Optional[PendingAtom]:
         """通过 pending alias 查询。"""
         return self._atoms.get(pending_alias)
+
+    def get_by_intent_id(self, intent_id: str) -> Optional[PendingAtom]:
+        """通过 intent_id 查询 pending atom。"""
+        pending_alias = self._intent_index.get(intent_id)
+        if pending_alias:
+            return self._atoms.get(pending_alias)
+        return None
 
     def has(self, alias: str) -> bool:
         """检查 alias 是否为已注册的 pending atom。"""
@@ -120,6 +188,7 @@ class PendingAtomCache:
     def clear(self) -> None:
         """清空全部 pending atom。"""
         self._atoms.clear()
+        self._intent_index.clear()
 
     @property
     def size(self) -> int:

--- a/src/hivememory/alice/runtime/core.py
+++ b/src/hivememory/alice/runtime/core.py
@@ -9,7 +9,9 @@ from hivememory.core.protocol.models import AgentRunContext, ChatResult
 from hivememory.alice.contracts.local_routes import AliceLocalRoutes
 from hivememory.alice.runtime.agent.runtime import AgentRuntime
 from hivememory.alice.runtime.bus import AliceBus
+from hivememory.alice.runtime.cache import KoakumaAtomCache, PendingAtomCache
 from hivememory.alice.runtime.koakuma import KoakumaRuntime
+from hivememory.alice.runtime.resolver import RuntimeAliasResolver
 from hivememory.alice.runtime.agent.mtp_executor import KoakumaMTPExecutor
 from hivememory.prompts.assembler import AgentPromptAssembler
 from hivememory.system.config import HiveMemoryConfig
@@ -32,23 +34,35 @@ class AliceRuntime:
         self._local_bus = AliceBus()
         self._local_routes_registered = False
 
+        self._pending_cache = PendingAtomCache()
+        self._atom_cache = KoakumaAtomCache()
+        self._alias_resolver = RuntimeAliasResolver(
+            pending_cache=self._pending_cache,
+            atom_cache=self._atom_cache,
+            bus=self._local_bus,
+        )
+
         self._koakuma = KoakumaRuntime(
             bus=self._local_bus,
             config=config.koakuma,
+            alias_resolver=self._alias_resolver,
         )
-        self._prompt_assembler = AgentPromptAssembler(config.koakuma)
         self._mtp_executor = KoakumaMTPExecutor(self._koakuma)
+
+        self._prompt_assembler = AgentPromptAssembler(config.koakuma)
+
         self._agent_runtime = AgentRuntime(
             local_bus=self._local_bus,
             prompt_assembler=self._prompt_assembler,
             mtp_executor=self._mtp_executor,
             config=config,
+            alias_resolver=self._alias_resolver,
         )
 
         logger.info("AliceRuntime 初始化完成")
 
     def register_preretrieval_aliases(self, memories: list[MemoryAtom]) -> None:
-        self._koakuma.atom_cache.ingest_atoms(memories)
+        self._atom_cache.ingest_atoms(memories)
         if memories:
             logger.debug(
                 f"预检索记忆缓存完成: {len(memories)} 条记忆已缓存到 Koakuma"

--- a/src/hivememory/alice/runtime/core.py
+++ b/src/hivememory/alice/runtime/core.py
@@ -15,6 +15,7 @@ from hivememory.alice.runtime.resolver import RuntimeAliasResolver
 from hivememory.alice.runtime.agent.mtp_executor import KoakumaMTPExecutor
 from hivememory.prompts.assembler import AgentPromptAssembler
 from hivememory.system.config import HiveMemoryConfig
+from hivememory.system.contracts.events import GlobalEvents
 from hivememory.system.contracts.routes import GlobalRoutes
 from hivememory.system.runtime.bus.global_bus import GlobalSystemBus
 
@@ -33,6 +34,7 @@ class AliceRuntime:
         self._global_bus = global_bus
         self._local_bus = AliceBus()
         self._local_routes_registered = False
+        self._global_events_registered = False
 
         self._pending_cache = PendingAtomCache()
         self._atom_cache = KoakumaAtomCache()
@@ -68,6 +70,14 @@ class AliceRuntime:
                 f"预检索记忆缓存完成: {len(memories)} 条记忆已缓存到 Koakuma"
             )
 
+    async def _on_pending_atom_settled(self, *, settlement) -> None:
+        """Handle settlement event from Patchouli generation pipeline."""
+        self._pending_cache.apply_settlement(settlement)
+        logger.info(
+            f"Settlement applied: {settlement.pending_alias} -> "
+            f"{settlement.status} (canonical={settlement.canonical_alias})"
+        )
+
     def mount_local_routes(self) -> None:
         if self._local_routes_registered:
             return
@@ -98,6 +108,12 @@ class AliceRuntime:
                 GlobalRoutes.PATCHOULI_RECORD_MEMORY_CITATION,
                 self._request_patchouli_record_memory_citation,
             )
+            if not self._global_events_registered:
+                self._global_bus.subscribe(
+                    GlobalEvents.PENDING_ATOM_SETTLED,
+                    self._on_pending_atom_settled,
+                )
+                self._global_events_registered = True
 
         self._local_routes_registered = True
 
@@ -112,6 +128,12 @@ class AliceRuntime:
             self._local_bus.unregister(GlobalRoutes.PATCHOULI_MEMORY_RETRIEVE_BY_ALIASES)
             self._local_bus.unregister(GlobalRoutes.PATCHOULI_GET_AGENT_PROFILE)
             self._local_bus.unregister(GlobalRoutes.PATCHOULI_RECORD_MEMORY_CITATION)
+            if self._global_events_registered:
+                self._global_bus.unsubscribe(
+                    GlobalEvents.PENDING_ATOM_SETTLED,
+                    self._on_pending_atom_settled,
+                )
+                self._global_events_registered = False
         self._local_routes_registered = False
 
     async def _request_patchouli_memory_retrieve(self, *args: Any, **kwargs: Any) -> Any:

--- a/src/hivememory/alice/runtime/core.py
+++ b/src/hivememory/alice/runtime/core.py
@@ -73,10 +73,42 @@ class AliceRuntime:
     async def _on_pending_atom_settled(self, *, settlement) -> None:
         """Handle settlement event from Patchouli generation pipeline."""
         self._pending_cache.apply_settlement(settlement)
+        await self._refresh_l1_cache_for_settlement(settlement)
         logger.info(
             f"Settlement applied: {settlement.pending_alias} -> "
             f"{settlement.status} (canonical={settlement.canonical_alias})"
         )
+
+    async def _refresh_l1_cache_for_settlement(self, settlement) -> None:
+        """Refresh L1 atom cache after a pending atom points to a canonical atom."""
+        canonical_alias = settlement.canonical_alias
+        if not canonical_alias:
+            return
+
+        self._atom_cache.invalidate_alias(canonical_alias)
+
+        try:
+            retrieval_response = await self._local_bus.request(
+                GlobalRoutes.PATCHOULI_MEMORY_RETRIEVE_BY_ALIASES,
+                aliases=[canonical_alias],
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Failed to refresh L1 cache for settled atom "
+                f"'{canonical_alias}': {exc}"
+            )
+            return
+
+        memories = getattr(retrieval_response, "memories", []) or []
+        memory = memories[0] if memories else None
+        if memory is None:
+            logger.debug(
+                f"No canonical atom returned while refreshing L1 cache: "
+                f"alias='{canonical_alias}'"
+            )
+            return
+
+        self._atom_cache.ingest_atom(memory)
 
     def mount_local_routes(self) -> None:
         if self._local_routes_registered:

--- a/src/hivememory/alice/runtime/koakuma.py
+++ b/src/hivememory/alice/runtime/koakuma.py
@@ -26,7 +26,6 @@
 
 import time
 import logging
-from uuid import UUID
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from hivememory.core.mtp import (
@@ -41,8 +40,10 @@ from hivememory.core.mtp import (
     MTPParseError,
     MTPFormatter,
 )
-from hivememory.alice.runtime.cache import KoakumaAtomCache
+from hivememory.alice.runtime.cache import KoakumaAtomCache, PendingAtomCache
 from hivememory.alice.runtime.models import MTPExecutionContext
+from hivememory.alice.runtime.pending_renderer import PendingAtomRenderer
+from hivememory.alice.runtime.resolver import RuntimeAliasResolver
 from hivememory.core.protocol.models import (
     MTPExecutionResult,
     RetrievalRequest,
@@ -55,13 +56,13 @@ from hivememory.core.mtp.exceptions import (
     SystemFault,
     StorageOfflineError,
     StorageReadError,
-    BusRouteUnavailableError,
     PermissionDeniedError,
 )
 from hivememory.engines.generation.models import WriteFocus, UpdateFocus
 
 if TYPE_CHECKING:
     from hivememory.alice.runtime.bus import AliceBus
+    from hivememory.alice.runtime.resolver import ResolveResult
     from hivememory.system.config import KoakumaConfig
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,8 @@ class KoakumaRuntime:
         self,
         bus: Optional["AliceBus"] = None,
         config: Optional["KoakumaConfig"] = None,
+        *,
+        alias_resolver: RuntimeAliasResolver,
     ):
         """
         初始化 Koakuma MTP 运行时
@@ -101,6 +104,7 @@ class KoakumaRuntime:
         Args:
             bus: AliceBus 实例，用于跨服务通信（纯异步总线）
             config: Koakuma 配置 (可选，使用默认值)
+            pending_cache: 共享的 PendingAtomCache 实例 (由 AliceRuntime 注入)
         """
         from hivememory.system.config import KoakumaConfig
 
@@ -110,7 +114,8 @@ class KoakumaRuntime:
         self._parser = MTPParser()
         self._filter_parser = MTPFilterParser()
         self._formatter = MTPFormatter()
-        self._atom_cache = KoakumaAtomCache()
+
+        self._alias_resolver = alias_resolver
 
         # 初始化内核工具注册表 KERNEL_REGISTRY (Section 4.2.1)
         # 硬编码的 sys_ 工具集，随系统启动加载，Zero Latency
@@ -220,6 +225,7 @@ class KoakumaRuntime:
                 execution_time_ms=response.execution_time_ms,
                 write_focus=response.write_focus,
                 update_focus=response.update_focus,
+                pending_alias=response.pending_alias,
             )
 
         except MTPParseError as e:
@@ -281,7 +287,12 @@ class KoakumaRuntime:
     @property
     def atom_cache(self) -> KoakumaAtomCache:
         """访问统一原子缓存"""
-        return self._atom_cache
+        return self._alias_resolver.atom_cache
+
+    @property
+    def pending_cache(self) -> PendingAtomCache:
+        """访问运行时 pending atom 缓存"""
+        return self._alias_resolver.pending_cache
 
     # ========== 内部路由 ==========
 
@@ -428,13 +439,14 @@ class KoakumaRuntime:
             content += "\n" + "\n".join(filter_warnings)
 
         # 将检索到的记忆原子缓存（完整对象，而非仅 UUID）
-        self._atom_cache.ingest_atoms(result.memories)
+        self.atom_cache.ingest_atoms(result.memories)
 
         return MTPResponse(
             status=MTPResponseStatus.SUCCESS,
             content=content,
         )
 
+    # TODO: 由MemoryCompiler统一接管渲染/编译逻辑
     async def _handle_read(
         self,
         command: MTPCommand,
@@ -467,20 +479,20 @@ class KoakumaRuntime:
                 content="READ requires at least one target alias.",
             )
 
-        # 解析别名 → MemoryAtom，分离有效与无效别名
-        # 统一缓存路径: 缓存命中 → L2 冷检索回退
-        # StorageOfflineError / BusRouteUnavailableError 会直接传播到 _route_and_execute
         resolved: List[Tuple[str, "MemoryAtom"]] = []  # (alias, atom)
+        resolved_pending: List[Tuple[str, Any]] = []  # (alias, PendingAtom)
         unresolved: List[str] = []
         for alias in aliases:
-            atom = await self._resolve_and_fetch(alias, context=context)
-            if atom is None:
-                unresolved.append(alias)
+            result = await self._alias_resolver.resolve(alias, context=context)
+            if result.kind == "pending" and result.pending is not None:
+                resolved_pending.append((alias, result.pending))
+            elif result.kind == "atom" and result.atom is not None:
+                resolved.append((alias, result.atom))
             else:
-                resolved.append((alias, atom))
+                unresolved.append(alias)
 
         # 全部无效：直接返回错误
-        if not resolved:
+        if not resolved and not resolved_pending:
             lines = [
                 f"[{a}]: [Alias Not Found] Alias '{a}' not found. "
                 f"Use SEARCH to discover the correct alias first."
@@ -492,10 +504,12 @@ class KoakumaRuntime:
             )
 
         # 直接从缓存的原子中提取内容（无需查询数据库）
-        read_results = self._format_cached_atoms(resolved)
+        read_results = self._format_cached_atoms(resolved) if resolved else {}
 
         # 组装输出
         output_lines: List[str] = []
+        for alias, pending in resolved_pending:
+            output_lines.append(PendingAtomRenderer.render_read(pending))
         for alias, _ in resolved:
             output_lines.append(read_results[alias])
         for alias in unresolved:
@@ -570,13 +584,23 @@ class KoakumaRuntime:
 
         # Level 1: 用户态工具路径 (统一原子缓存)
         # StorageOfflineError / BusRouteUnavailableError 会直接传播到 _route_and_execute
-        atom = await self._resolve_and_fetch(alias, context=context)
-        if atom is None:
+        resolved = await self._alias_resolver.resolve(alias, context=context)
+        if resolved.kind == "pending":
+            return MTPResponse(
+                status=MTPResponseStatus.ERROR,
+                content=(
+                    f"[Pending Alias Not Runnable] Alias '{alias}' is a runtime "
+                    "pending atom and has not been finalized as a runnable memory. "
+                    "Use READ to inspect it, or wait for the formal memory alias."
+                ),
+            )
+        if resolved.kind != "atom" or resolved.atom is None:
             return MTPResponse(
                 status=MTPResponseStatus.ERROR,
                 content=f"[Alias Not Found] Tool alias '{alias}' not found. "
                         f"Use SEARCH to discover the correct alias first.",
             )
+        atom = resolved.atom
 
         # 校验类型必须是 CODE_SNIPPET
         if atom.index.memory_type != MemoryType.CODE_SNIPPET:
@@ -626,6 +650,16 @@ class KoakumaRuntime:
         reason = command.args.get("reason", "")
         title = command.args.get("title", "")
 
+        # 注册 pending atom 并生成 pending alias
+        pending = self.pending_cache.register_write(
+            content=content,
+            title=title or None,
+            reason=reason or None,
+            identity=context.identity,
+            frame_id="",
+            depth=context.depth,
+        )
+
         # 构建 WriteFocus 并交给调用方随本轮结果汇总 (不再直接调用 Librarian)
         write_focus = WriteFocus(
             content=content,
@@ -635,13 +669,15 @@ class KoakumaRuntime:
         )
 
         logger.info(
-            f"MTP WRITE 延迟捕获: content='{content[:50]}...', reason='{reason}'"
+            f"MTP WRITE 延迟捕获: content='{content[:50]}...', "
+            f"pending_alias='{pending.pending_alias}'"
         )
 
         return MTPResponse(
             status=MTPResponseStatus.ACK,
-            content='Memory saved.',
+            content=PendingAtomRenderer.render_ack(pending),
             write_focus=write_focus,
+            pending_alias=pending.pending_alias,
         )
 
     async def _handle_update(
@@ -683,19 +719,39 @@ class KoakumaRuntime:
 
         # 3. 解析 alias → MemoryAtom (统一缓存路径)
         # StorageOfflineError / BusRouteUnavailableError 会直接传播到 _route_and_execute
-        atom = await self._resolve_and_fetch(alias, context=context)
-        if atom is None:
+        resolved = await self._alias_resolver.resolve(alias, context=context)
+        if resolved.kind == "pending":
+            return MTPResponse(
+                status=MTPResponseStatus.ERROR,
+                content=(
+                    f"[Pending Alias Not Updatable] Alias '{alias}' is a runtime "
+                    "pending atom. UPDATE requires a formal memory alias."
+                ),
+            )
+        if resolved.kind != "atom" or resolved.atom is None:
             return MTPResponse(
                 status=MTPResponseStatus.ERROR,
                 content=f"[Alias Not Found] Alias '{alias}' not found. "
                         f"Use SEARCH to discover the correct alias first.",
             )
+        atom = resolved.atom
         uuid = str(atom.id)
 
         # 4. 获取可选的 content
         content = command.args.get("content", None)
 
-        # 5. 构建 UpdateFocus 并交给调用方随本轮结果汇总 (不再直接调用 Librarian)
+        # 5. 注册 pending revision
+        pending = self.pending_cache.register_update(
+            target_alias=alias,
+            target_uuid=uuid,
+            instruction=instruction,
+            content=content,
+            identity=context.identity,
+            frame_id="",
+            depth=context.depth,
+        )
+
+        # 6. 构建 UpdateFocus 并交给调用方随本轮结果汇总 (不再直接调用 Librarian)
         update_focus = UpdateFocus(
             instruction=instruction,
             content=content if content else None,
@@ -704,17 +760,19 @@ class KoakumaRuntime:
             identity=context.identity,
         )
 
-        # 6. 使缓存失效，防止脏读
-        self._atom_cache.invalidate_alias(alias)
+        # 7. 使缓存失效，防止脏读
+        self.atom_cache.invalidate_alias(alias)
 
         logger.info(
-            f"MTP UPDATE 延迟捕获: alias='{alias}', instruction='{instruction[:50]}'"
+            f"MTP UPDATE 延迟捕获: alias='{alias}', "
+            f"pending_alias='{pending.pending_alias}'"
         )
 
         return MTPResponse(
             status=MTPResponseStatus.ACK,
-            content=f"Memory '{alias}' updated successfully.",
+            content=PendingAtomRenderer.render_ack(pending),
             update_focus=update_focus,
+            pending_alias=pending.pending_alias,
         )
 
     async def _handle_call(
@@ -831,71 +889,6 @@ class KoakumaRuntime:
                 source,
                 exc_info=True,
             )
-
-    async def _resolve_and_fetch(
-        self,
-        alias: str,
-        context: Optional[MTPExecutionContext] = None,
-    ) -> Optional["MemoryAtom"]:
-        """
-        统一的别名解析与原子获取
-
-        先检查缓存，未命中则查询存储并缓存结果。
-        替代原有的 L1/L2 分离解析模式。
-
-        Raises:
-            StorageOfflineError: 存储层离线
-            StorageReadError: 存储层响应异常
-            BusRouteUnavailableError: 系统总线路由缺失
-
-        Args:
-            alias: 语义化别名
-
-        Returns:
-            MemoryAtom 对象，未命中返回 None
-        """
-        # 检查缓存
-        atom = self._atom_cache.get_atom_by_alias(alias)
-        if atom is not None:
-            logger.debug(f"Atom cache hit: alias='{alias}'")
-            return atom
-
-        # 缓存未命中：查询存储（L2 冷检索）
-        try:
-            identity = context.identity if context is not None else MTPExecutionContext().identity
-            retrieval_response = await self._bus.request(
-                GlobalRoutes.PATCHOULI_MEMORY_RETRIEVE_BY_ALIASES,
-                aliases=[alias],
-                identity=identity,
-            )
-            memories = getattr(retrieval_response, "memories", []) or []
-            memory = memories[0] if memories else None
-            if memory is None:
-                logger.debug(f"L2 cold-lookup miss: alias='{alias}'")
-                return None
-
-            uuid_str = str(memory.id)
-            # 校验 UUID 格式有效性，防止脏数据污染缓存
-            UUID(uuid_str)
-
-            # 缓存完整原子
-            self._atom_cache.ingest_atom(memory)
-            logger.debug(
-                f"L2 cold-lookup hit: alias='{alias}' -> {uuid_str}, cached"
-            )
-            return memory
-        except KeyError as e:
-            logger.error(f"L2 cold-lookup route unavailable: alias='{alias}', error={e}")
-            raise BusRouteUnavailableError(
-                "Memory storage service is not available."
-            ) from e
-        except (StorageOfflineError, StorageReadError):
-            raise  # propagate as-is
-        except Exception as e:
-            logger.error(f"L2 cold-lookup infrastructure failure: alias='{alias}', error={e}")
-            raise StorageReadError(
-                "Memory storage encountered an error during alias lookup."
-            ) from e
 
     def _execute_user_tool(
         self, alias: str, code: str, args: Dict[str, str]

--- a/src/hivememory/alice/runtime/koakuma.py
+++ b/src/hivememory/alice/runtime/koakuma.py
@@ -58,8 +58,6 @@ from hivememory.core.mtp.exceptions import (
     StorageReadError,
     PermissionDeniedError,
 )
-from hivememory.engines.generation.models import WriteFocus, UpdateFocus
-
 if TYPE_CHECKING:
     from hivememory.alice.runtime.bus import AliceBus
     from hivememory.alice.runtime.resolver import ResolveResult
@@ -659,14 +657,6 @@ class KoakumaRuntime:
             runtime_scope=context.runtime_scope,
         )
 
-        # 构建 WriteFocus 并交给调用方随本轮结果汇总 (不再直接调用 Librarian)
-        write_focus = WriteFocus(
-            content=content,
-            reason=reason or None,
-            title=title or None,
-            identity=context.identity,
-        )
-
         logger.info(
             f"MTP WRITE 延迟捕获: content='{content[:50]}...', "
             f"pending_alias='{pending.pending_alias}'"
@@ -675,7 +665,7 @@ class KoakumaRuntime:
         return MTPResponse(
             status=MTPResponseStatus.ACK,
             content=PendingAtomRenderer.render_ack(pending),
-            write_focus=write_focus,
+            write_focus=pending.focus,
             pending_alias=pending.pending_alias,
         )
 
@@ -741,21 +731,12 @@ class KoakumaRuntime:
 
         # 5. 注册 pending revision
         pending = self.pending_cache.register_update(
-            target_alias=alias,
-            target_uuid=uuid,
+            base_alias=alias,
+            base_uuid=uuid,
             instruction=instruction,
             content=content,
             identity=context.identity,
             runtime_scope=context.runtime_scope,
-        )
-
-        # 6. 构建 UpdateFocus 并交给调用方随本轮结果汇总 (不再直接调用 Librarian)
-        update_focus = UpdateFocus(
-            instruction=instruction,
-            content=content if content else None,
-            target_uuid=uuid,
-            target_alias=alias,
-            identity=context.identity,
         )
 
         # 7. 使缓存失效，防止脏读
@@ -769,7 +750,7 @@ class KoakumaRuntime:
         return MTPResponse(
             status=MTPResponseStatus.ACK,
             content=PendingAtomRenderer.render_ack(pending),
-            update_focus=update_focus,
+            update_focus=pending.focus,
             pending_alias=pending.pending_alias,
         )
 

--- a/src/hivememory/alice/runtime/koakuma.py
+++ b/src/hivememory/alice/runtime/koakuma.py
@@ -656,7 +656,8 @@ class KoakumaRuntime:
             title=title or None,
             reason=reason or None,
             identity=context.identity,
-            frame_id="",
+            run_id=context.run_id,
+            frame_id=context.frame_id,
             depth=context.depth,
         )
 
@@ -747,7 +748,8 @@ class KoakumaRuntime:
             instruction=instruction,
             content=content,
             identity=context.identity,
-            frame_id="",
+            run_id=context.run_id,
+            frame_id=context.frame_id,
             depth=context.depth,
         )
 

--- a/src/hivememory/alice/runtime/koakuma.py
+++ b/src/hivememory/alice/runtime/koakuma.py
@@ -656,9 +656,7 @@ class KoakumaRuntime:
             title=title or None,
             reason=reason or None,
             identity=context.identity,
-            run_id=context.run_id,
-            frame_id=context.frame_id,
-            depth=context.depth,
+            runtime_scope=context.runtime_scope,
         )
 
         # 构建 WriteFocus 并交给调用方随本轮结果汇总 (不再直接调用 Librarian)
@@ -748,9 +746,7 @@ class KoakumaRuntime:
             instruction=instruction,
             content=content,
             identity=context.identity,
-            run_id=context.run_id,
-            frame_id=context.frame_id,
-            depth=context.depth,
+            runtime_scope=context.runtime_scope,
         )
 
         # 6. 构建 UpdateFocus 并交给调用方随本轮结果汇总 (不再直接调用 Librarian)
@@ -801,7 +797,7 @@ class KoakumaRuntime:
         import json
 
         # 1. 深度检查 (硬限制)
-        if context is not None and context.depth >= 1:
+        if context is not None and context.runtime_scope.depth >= 1:
             raise PermissionDeniedError(
                 "Sub-agents are not allowed to invoke CALL. "
                 "Only the main agent can call sub-agents."

--- a/src/hivememory/alice/runtime/koakuma.py
+++ b/src/hivememory/alice/runtime/koakuma.py
@@ -479,18 +479,24 @@ class KoakumaRuntime:
 
         resolved: List[Tuple[str, "MemoryAtom"]] = []  # (alias, atom)
         resolved_pending: List[Tuple[str, Any]] = []  # (alias, PendingAtom)
+        resolved_redirects: List[Tuple[str, Any]] = []  # (alias, ResolveResult)
+        resolved_settled: List[Tuple[str, Any]] = []  # (alias, ResolveResult)
         unresolved: List[str] = []
         for alias in aliases:
             result = await self._alias_resolver.resolve(alias, context=context)
             if result.kind == "pending" and result.pending is not None:
                 resolved_pending.append((alias, result.pending))
+            elif result.kind == "redirect" and result.atom is not None:
+                resolved_redirects.append((alias, result))
             elif result.kind == "atom" and result.atom is not None:
                 resolved.append((alias, result.atom))
+            elif result.kind in {"discarded", "failed"}:
+                resolved_settled.append((alias, result))
             else:
                 unresolved.append(alias)
 
         # 全部无效：直接返回错误
-        if not resolved and not resolved_pending:
+        if not resolved and not resolved_pending and not resolved_redirects and not resolved_settled:
             lines = [
                 f"[{a}]: [Alias Not Found] Alias '{a}' not found. "
                 f"Use SEARCH to discover the correct alias first."
@@ -508,6 +514,23 @@ class KoakumaRuntime:
         output_lines: List[str] = []
         for alias, pending in resolved_pending:
             output_lines.append(PendingAtomRenderer.render_read(pending))
+        for alias, result in resolved_redirects:
+            canonical_alias = result.canonical_alias or result.atom.get_alias()
+            output_lines.append(
+                PendingAtomRenderer.render_redirect_read(
+                    requested_alias=alias,
+                    canonical_alias=canonical_alias,
+                    atom=result.atom,
+                    settlement=result.settlement,
+                )
+            )
+        for alias, result in resolved_settled:
+            output_lines.append(
+                PendingAtomRenderer.render_settled_without_atom(
+                    requested_alias=alias,
+                    settlement=result.settlement,
+                )
+            )
         for alias, _ in resolved:
             output_lines.append(read_results[alias])
         for alias in unresolved:
@@ -522,6 +545,8 @@ class KoakumaRuntime:
         )
         for _, atom in resolved:
             await self._record_memory_citation(atom, "mtp.read")
+        for _, result in resolved_redirects:
+            await self._record_memory_citation(result.atom, "mtp.read")
         return response
 
     # TODO:检查run返回的MTP结果为何为误导模型认为执行失败，尽管显示执行成功
@@ -583,6 +608,7 @@ class KoakumaRuntime:
         # Level 1: 用户态工具路径 (统一原子缓存)
         # StorageOfflineError / BusRouteUnavailableError 会直接传播到 _route_and_execute
         resolved = await self._alias_resolver.resolve(alias, context=context)
+        redirect_notice = ""
         if resolved.kind == "pending":
             return MTPResponse(
                 status=MTPResponseStatus.ERROR,
@@ -592,7 +618,23 @@ class KoakumaRuntime:
                     "Use READ to inspect it, or wait for the formal memory alias."
                 ),
             )
-        if resolved.kind != "atom" or resolved.atom is None:
+        if resolved.kind == "redirect" and resolved.atom is not None:
+            canonical_alias = resolved.canonical_alias or resolved.atom.get_alias()
+            redirect_notice = PendingAtomRenderer.render_redirect_run_notice(
+                requested_alias=alias,
+                canonical_alias=canonical_alias,
+                settlement=resolved.settlement,
+            )
+            alias = canonical_alias
+        elif resolved.kind in {"discarded", "failed"}:
+            return MTPResponse(
+                status=MTPResponseStatus.ERROR,
+                content=PendingAtomRenderer.render_settled_without_atom(
+                    requested_alias=alias,
+                    settlement=resolved.settlement,
+                ),
+            )
+        if resolved.kind not in {"atom", "redirect"} or resolved.atom is None:
             return MTPResponse(
                 status=MTPResponseStatus.ERROR,
                 content=f"[Alias Not Found] Tool alias '{alias}' not found. "
@@ -613,6 +655,8 @@ class KoakumaRuntime:
         code = atom.payload.content
         logger.info(f"User tool executing: alias='{alias}', UUID={atom.id}")
         response = self._execute_user_tool(alias, code, command.args)
+        if redirect_notice:
+            response.content = f"{redirect_notice}{response.content}"
         if response.status == MTPResponseStatus.SUCCESS:
             await self._record_memory_citation(atom, "mtp.run")
         return response

--- a/src/hivememory/alice/runtime/models.py
+++ b/src/hivememory/alice/runtime/models.py
@@ -3,9 +3,42 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
 
 from hivememory.core.models import AgentProfile, Identity
+from pydantic import BaseModel, Field
+
+
+class PendingAtomStatus(str, Enum):
+    """Pending atom 的运行时状态。"""
+
+    PENDING = "pending"
+    REVISION = "revision"
+
+
+class PendingAtom(BaseModel):
+    """
+    运行时待物化记忆句柄。
+
+    不是正式 MemoryAtom，不承诺最终落库。
+    在其生命周期内，Agent 可通过 pending_alias 读取本次写入意图的内容。
+    """
+
+    pending_alias: str
+    status: PendingAtomStatus
+    source_verb: Literal["WRITE", "UPDATE"]
+    content: str
+    title: Optional[str] = None
+    reason: Optional[str] = None
+    instruction: Optional[str] = None
+    target_alias: Optional[str] = None
+    target_uuid: Optional[str] = None
+    identity: Identity = Field(default_factory=Identity)
+    frame_id: str = ""
+    depth: int = 0
+    created_at: datetime = Field(default_factory=datetime.now)
 
 
 @dataclass
@@ -90,5 +123,7 @@ __all__ = [
     "ExecutionFrame",
     "GenerationResult",
     "MTPExecutionContext",
+    "PendingAtom",
+    "PendingAtomStatus",
     "StreamChunk",
 ]

--- a/src/hivememory/alice/runtime/models.py
+++ b/src/hivememory/alice/runtime/models.py
@@ -8,6 +8,11 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
 from hivememory.core.models import AgentProfile, Identity
+from hivememory.engines.generation.models import (
+    PendingAtomSettlement,
+    UpdateFocus,
+    WriteFocus,
+)
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -16,6 +21,13 @@ class PendingAtomStatus(str, Enum):
 
     PENDING = "pending"
     REVISION = "revision"
+    # Phase 2: settlement states
+    COMMITTED = "committed"
+    MERGED = "merged"
+    UPDATED = "updated"
+    TOUCHED = "touched"
+    DISCARDED = "discarded"
+    FAILED = "failed"
 
 
 class RuntimeScope(BaseModel):
@@ -52,17 +64,17 @@ class PendingAtom(BaseModel):
     """
 
     pending_alias: str
+    intent_id: Optional[str] = None
     status: PendingAtomStatus
     source_verb: Literal["WRITE", "UPDATE"]
-    content: str
-    title: Optional[str] = None
-    reason: Optional[str] = None
-    instruction: Optional[str] = None
-    target_alias: Optional[str] = None
-    target_uuid: Optional[str] = None
+
+    focus: WriteFocus | UpdateFocus
     identity: Identity = Field(default_factory=Identity)
     runtime_scope: RuntimeScope = Field(default_factory=RuntimeScope)
     created_at: datetime = Field(default_factory=datetime.now)
+
+    # Phase 2: settlement tracking
+    settlement: Optional[PendingAtomSettlement] = None
 
 
 @dataclass

--- a/src/hivememory/alice/runtime/models.py
+++ b/src/hivememory/alice/runtime/models.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
 from hivememory.core.models import AgentProfile, Identity
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PendingAtomStatus(str, Enum):
@@ -16,6 +16,31 @@ class PendingAtomStatus(str, Enum):
 
     PENDING = "pending"
     REVISION = "revision"
+
+
+class RuntimeScope(BaseModel):
+    """Runtime execution coordinates for an Alice agent run."""
+
+    run_id: str = ""
+    frame_id: str = ""
+    parent_frame_id: Optional[str] = None
+    action_id: Optional[str] = None
+    depth: int = 0
+
+    def with_action(self, action_id: str) -> "RuntimeScope":
+        """Return a copy scoped to one agent action."""
+        return self.model_copy(update={"action_id": action_id})
+
+    def for_child(self, frame_id: str) -> "RuntimeScope":
+        """Return a child frame scope under the same run."""
+        return RuntimeScope(
+            run_id=self.run_id,
+            frame_id=frame_id,
+            parent_frame_id=self.frame_id,
+            depth=self.depth + 1,
+        )
+
+    model_config = ConfigDict(frozen=True)
 
 
 class PendingAtom(BaseModel):
@@ -36,9 +61,7 @@ class PendingAtom(BaseModel):
     target_alias: Optional[str] = None
     target_uuid: Optional[str] = None
     identity: Identity = Field(default_factory=Identity)
-    run_id: str = ""
-    frame_id: str = ""
-    depth: int = 0
+    runtime_scope: RuntimeScope = Field(default_factory=RuntimeScope)
     created_at: datetime = Field(default_factory=datetime.now)
 
 
@@ -52,24 +75,21 @@ class ExecutionFrame:
     shared runtime.
     """
 
-    process_id: str
+    runtime_scope: RuntimeScope
     agent_profile: AgentProfile
     working_history: List[Dict[str, str]]
-    depth: int
     topic_id: Optional[str]
     identity: Identity
 
-    run_id: str = ""
-    parent_frame_id: Optional[str] = None
     harvested_aliases: List[str] = field(default_factory=list)
 
     def is_main_frame(self) -> bool:
         """Return True when this frame belongs to the main agent."""
-        return self.depth == 0
+        return self.runtime_scope.depth == 0
 
     def is_sub_frame(self) -> bool:
         """Return True when this frame belongs to a sub-agent."""
-        return self.depth >= 1
+        return self.runtime_scope.depth >= 1
 
     def is_transient(self) -> bool:
         """Return True when this frame is not mounted to a topic."""
@@ -82,9 +102,9 @@ class ExecutionFrame:
 
     def __repr__(self) -> str:
         return (
-            f"ExecutionFrame(pid={self.process_id}, "
+            f"ExecutionFrame(frame={self.runtime_scope.frame_id}, "
             f"agent={self.agent_profile.model_name}, "
-            f"depth={self.depth}, "
+            f"depth={self.runtime_scope.depth}, "
             f"topic={self.topic_id}, "
             f"harvested={len(self.harvested_aliases)})"
         )
@@ -96,9 +116,7 @@ class MTPExecutionContext:
 
     identity: Identity = field(default_factory=Identity)
     agent_profile: Any = None
-    run_id: str = ""
-    frame_id: str = ""
-    depth: int = 0
+    runtime_scope: RuntimeScope = field(default_factory=RuntimeScope)
 
 
 @dataclass
@@ -129,5 +147,6 @@ __all__ = [
     "MTPExecutionContext",
     "PendingAtom",
     "PendingAtomStatus",
+    "RuntimeScope",
     "StreamChunk",
 ]

--- a/src/hivememory/alice/runtime/models.py
+++ b/src/hivememory/alice/runtime/models.py
@@ -36,6 +36,7 @@ class PendingAtom(BaseModel):
     target_alias: Optional[str] = None
     target_uuid: Optional[str] = None
     identity: Identity = Field(default_factory=Identity)
+    run_id: str = ""
     frame_id: str = ""
     depth: int = 0
     created_at: datetime = Field(default_factory=datetime.now)
@@ -58,6 +59,7 @@ class ExecutionFrame:
     topic_id: Optional[str]
     identity: Identity
 
+    run_id: str = ""
     parent_frame_id: Optional[str] = None
     harvested_aliases: List[str] = field(default_factory=list)
 
@@ -94,6 +96,8 @@ class MTPExecutionContext:
 
     identity: Identity = field(default_factory=Identity)
     agent_profile: Any = None
+    run_id: str = ""
+    frame_id: str = ""
     depth: int = 0
 
 

--- a/src/hivememory/alice/runtime/pending_renderer.py
+++ b/src/hivememory/alice/runtime/pending_renderer.py
@@ -11,6 +11,7 @@ PendingAtom 渲染器。
 from __future__ import annotations
 
 from hivememory.alice.runtime.models import PendingAtom, PendingAtomStatus
+from hivememory.engines.generation.models import UpdateFocus, WriteFocus
 
 
 class PendingAtomRenderer:
@@ -25,14 +26,18 @@ class PendingAtomRenderer:
 
     @staticmethod
     def _render_draft_read(pending: PendingAtom) -> str:
+        focus = pending.focus
+        if not isinstance(focus, WriteFocus):
+            raise TypeError("WRITE pending atom must carry WriteFocus.")
+
         lines = [f"[{pending.pending_alias}] (runtime pending atom):"]
         lines.append("status: pending")
         lines.append("source: WRITE")
-        if pending.title:
-            lines.append(f"title: {pending.title}")
+        if focus.title:
+            lines.append(f"title: {focus.title}")
         lines.append("")
         lines.append("content:")
-        lines.append(pending.content)
+        lines.append(focus.content)
         lines.append("")
         lines.append(
             "note: This is a runtime pending atom. "
@@ -42,16 +47,20 @@ class PendingAtomRenderer:
 
     @staticmethod
     def _render_revision_read(pending: PendingAtom) -> str:
+        focus = pending.focus
+        if not isinstance(focus, UpdateFocus):
+            raise TypeError("UPDATE pending atom must carry UpdateFocus.")
+
         lines = [
             f"[{pending.pending_alias}] "
-            f"(pending revision of '{pending.target_alias}'):"
+            f"(pending revision of '{focus.base_alias}'):"
         ]
         lines.append("status: revision")
-        if pending.instruction:
-            lines.append(f"instruction: {pending.instruction}")
+        if focus.instruction:
+            lines.append(f"instruction: {focus.instruction}")
         lines.append("")
         lines.append("new content:")
-        lines.append(pending.content)
+        lines.append(focus.content or "")
         lines.append("")
         lines.append(
             "note: This is a pending revision. "
@@ -63,8 +72,11 @@ class PendingAtomRenderer:
     def render_ack(pending: PendingAtom) -> str:
         """渲染 WRITE/UPDATE ACK 回填文案。"""
         if pending.status == PendingAtomStatus.REVISION:
+            focus = pending.focus
+            if not isinstance(focus, UpdateFocus):
+                raise TypeError("UPDATE pending atom must carry UpdateFocus.")
             return (
-                f"Memory '{pending.target_alias}' update accepted as "
+                f"Memory '{focus.base_alias}' update accepted as "
                 f"pending revision '{pending.pending_alias}'.\n"
                 f"It is readable during this run via READ. "
                 f"Final memory update will complete asynchronously."

--- a/src/hivememory/alice/runtime/pending_renderer.py
+++ b/src/hivememory/alice/runtime/pending_renderer.py
@@ -11,7 +11,12 @@ PendingAtom 渲染器。
 from __future__ import annotations
 
 from hivememory.alice.runtime.models import PendingAtom, PendingAtomStatus
-from hivememory.engines.generation.models import UpdateFocus, WriteFocus
+from hivememory.core.models import MemoryAtom
+from hivememory.engines.generation.models import (
+    PendingAtomSettlement,
+    UpdateFocus,
+    WriteFocus,
+)
 
 
 class PendingAtomRenderer:
@@ -86,6 +91,72 @@ class PendingAtomRenderer:
             f"It is readable during this run via READ. "
             f"Final memory generation will complete asynchronously."
         )
+
+    @staticmethod
+    def render_redirect_read(
+        *,
+        requested_alias: str,
+        canonical_alias: str,
+        atom: MemoryAtom,
+        settlement: PendingAtomSettlement | None = None,
+    ) -> str:
+        """渲染 READ redirect 响应，主体使用 canonical alias。"""
+        status = settlement.status.lower() if settlement else "redirected"
+        lines = [
+            "[Alias Redirected]",
+            f"Requested alias: {requested_alias}",
+            f"Canonical alias: {canonical_alias}",
+            f"Status: {status}",
+            "",
+            f"[{canonical_alias}]:",
+            atom.payload.content,
+            "",
+            f"Action: Use '{canonical_alias}' for future READ/RUN/UPDATE calls.",
+        ]
+        return "\n".join(lines)
+
+    @staticmethod
+    def render_redirect_run_notice(
+        *,
+        requested_alias: str,
+        canonical_alias: str,
+        settlement: PendingAtomSettlement | None = None,
+    ) -> str:
+        """渲染 RUN redirect 提示头。"""
+        status = settlement.status.lower() if settlement else "redirected"
+        return "\n".join(
+            [
+                "[Alias Redirected]",
+                f"Requested alias: {requested_alias}",
+                f"Canonical alias: {canonical_alias}",
+                f"Status: {status}",
+                f"Action: Use '{canonical_alias}' for future RUN calls.",
+                "",
+            ]
+        )
+
+    @staticmethod
+    def render_settled_without_atom(
+        *,
+        requested_alias: str,
+        settlement: PendingAtomSettlement | None,
+    ) -> str:
+        """渲染已结算但未物化为 canonical atom 的 pending alias。"""
+        status = settlement.status.lower() if settlement else "settled"
+        message = settlement.message if settlement and settlement.message else ""
+        reason = settlement.reason if settlement and settlement.reason else ""
+        lines = [
+            f"[{requested_alias}]",
+            f"status: {status}",
+            "materialized: false",
+        ]
+        if message:
+            lines.append(f"message: {message}")
+        if reason:
+            lines.append(f"reason: {reason}")
+        lines.append("")
+        lines.append("Action: Use SEARCH to locate related finalized memory if needed.")
+        return "\n".join(lines)
 
 
 __all__ = ["PendingAtomRenderer"]

--- a/src/hivememory/alice/runtime/pending_renderer.py
+++ b/src/hivememory/alice/runtime/pending_renderer.py
@@ -1,0 +1,79 @@
+"""
+PendingAtom 渲染器。
+
+负责将 PendingAtom 格式化为 Agent 可读的文本输出，
+用于 READ 响应和 WRITE/UPDATE ACK 回填。
+
+作者: HiveMemory Team
+版本: 1.0
+"""
+
+from __future__ import annotations
+
+from hivememory.alice.runtime.models import PendingAtom, PendingAtomStatus
+
+
+class PendingAtomRenderer:
+    """MVP 阶段的 pending atom 渲染器，未来由 MemoryCompiler 接管。"""
+
+    @staticmethod
+    def render_read(pending: PendingAtom) -> str:
+        """渲染 READ 响应内容。"""
+        if pending.status == PendingAtomStatus.REVISION:
+            return PendingAtomRenderer._render_revision_read(pending)
+        return PendingAtomRenderer._render_draft_read(pending)
+
+    @staticmethod
+    def _render_draft_read(pending: PendingAtom) -> str:
+        lines = [f"[{pending.pending_alias}] (runtime pending atom):"]
+        lines.append("status: pending")
+        lines.append("source: WRITE")
+        if pending.title:
+            lines.append(f"title: {pending.title}")
+        lines.append("")
+        lines.append("content:")
+        lines.append(pending.content)
+        lines.append("")
+        lines.append(
+            "note: This is a runtime pending atom. "
+            "Final memory generation is asynchronous."
+        )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _render_revision_read(pending: PendingAtom) -> str:
+        lines = [
+            f"[{pending.pending_alias}] "
+            f"(pending revision of '{pending.target_alias}'):"
+        ]
+        lines.append("status: revision")
+        if pending.instruction:
+            lines.append(f"instruction: {pending.instruction}")
+        lines.append("")
+        lines.append("new content:")
+        lines.append(pending.content)
+        lines.append("")
+        lines.append(
+            "note: This is a pending revision. "
+            "The original memory has not been modified yet."
+        )
+        return "\n".join(lines)
+
+    @staticmethod
+    def render_ack(pending: PendingAtom) -> str:
+        """渲染 WRITE/UPDATE ACK 回填文案。"""
+        if pending.status == PendingAtomStatus.REVISION:
+            return (
+                f"Memory '{pending.target_alias}' update accepted as "
+                f"pending revision '{pending.pending_alias}'.\n"
+                f"It is readable during this run via READ. "
+                f"Final memory update will complete asynchronously."
+            )
+        return (
+            f"Memory accepted as pending atom '{pending.pending_alias}'.\n"
+            f"It is readable during this run via READ. "
+            f"Final memory generation will complete asynchronously."
+        )
+
+
+__all__ = ["PendingAtomRenderer"]

--- a/src/hivememory/alice/runtime/resolver.py
+++ b/src/hivememory/alice/runtime/resolver.py
@@ -18,8 +18,9 @@ from typing import TYPE_CHECKING, Literal, Optional
 from uuid import UUID
 
 from hivememory.alice.runtime.cache import PendingAtomCache
-from hivememory.alice.runtime.models import PendingAtom
+from hivememory.alice.runtime.models import PendingAtom, PendingAtomStatus
 from hivememory.core.models import MemoryAtom
+from hivememory.engines.generation.models import PendingAtomSettlement
 from hivememory.core.mtp.exceptions import (
     BusRouteUnavailableError,
     StorageOfflineError,
@@ -38,9 +39,13 @@ logger = logging.getLogger(__name__)
 class ResolveResult:
     """别名解析结果。"""
 
-    kind: Literal["pending", "atom", "not_found"]
+    kind: Literal["pending", "redirect", "discarded", "failed", "atom", "not_found"]
+    requested_alias: Optional[str] = field(default=None)
+    canonical_alias: Optional[str] = field(default=None)
+    canonical_uuid: Optional[str] = field(default=None)
     pending: Optional[PendingAtom] = field(default=None)
     atom: Optional[MemoryAtom] = field(default=None)
+    settlement: Optional[PendingAtomSettlement] = field(default=None)
 
 
 class RuntimeAliasResolver:
@@ -73,26 +78,94 @@ class RuntimeAliasResolver:
         三级解析 alias。
 
         Returns:
-            ResolveResult: kind="pending" / "atom" / "not_found"
+            ResolveResult: kind="pending" / "redirect" / "discarded" / "failed" / "atom" / "not_found"
         """
         # L0: PendingAtomCache
         pending = self._pending_cache.get(alias)
         if pending is not None:
             logger.debug(f"L0 pending cache hit: alias='{alias}'")
-            return ResolveResult(kind="pending", pending=pending)
+            return await self._resolve_pending_hit(pending, alias, context)
 
         # L1: KoakumaAtomCache
         atom = self._atom_cache.get_atom_by_alias(alias)
         if atom is not None:
             logger.debug(f"L1 atom cache hit: alias='{alias}'")
-            return ResolveResult(kind="atom", atom=atom)
+            return ResolveResult(kind="atom", requested_alias=alias, atom=atom)
 
         # L2: Storage cold lookup
         atom = await self._cold_lookup(alias, context)
         if atom is not None:
-            return ResolveResult(kind="atom", atom=atom)
+            return ResolveResult(kind="atom", requested_alias=alias, atom=atom)
 
-        return ResolveResult(kind="not_found")
+        return ResolveResult(kind="not_found", requested_alias=alias)
+
+    async def _resolve_pending_hit(
+        self,
+        pending: PendingAtom,
+        alias: str,
+        context: Optional["MTPExecutionContext"] = None,
+    ) -> ResolveResult:
+        """Resolve an L0 pending entry, including settled redirect states."""
+        settlement = pending.settlement or self._pending_cache.get_redirect(alias)
+        if pending.status in {PendingAtomStatus.PENDING, PendingAtomStatus.REVISION}:
+            return ResolveResult(
+                kind="pending",
+                requested_alias=alias,
+                pending=pending,
+                settlement=settlement,
+            )
+
+        if pending.status == PendingAtomStatus.DISCARDED:
+            return ResolveResult(
+                kind="discarded",
+                requested_alias=alias,
+                pending=pending,
+                settlement=settlement,
+            )
+
+        if pending.status == PendingAtomStatus.FAILED:
+            return ResolveResult(
+                kind="failed",
+                requested_alias=alias,
+                pending=pending,
+                settlement=settlement,
+            )
+
+        if settlement is not None and (
+            settlement.canonical_alias or settlement.canonical_uuid
+        ):
+            atom = self._resolve_cached_canonical(settlement)
+            if atom is None and settlement.canonical_alias:
+                atom = await self._cold_lookup(settlement.canonical_alias, context)
+
+            return ResolveResult(
+                kind="redirect",
+                requested_alias=alias,
+                canonical_alias=settlement.canonical_alias,
+                canonical_uuid=settlement.canonical_uuid,
+                pending=pending,
+                atom=atom,
+                settlement=settlement,
+            )
+
+        return ResolveResult(
+            kind="pending",
+            requested_alias=alias,
+            pending=pending,
+            settlement=settlement,
+        )
+
+    def _resolve_cached_canonical(
+        self,
+        settlement: PendingAtomSettlement,
+    ) -> Optional[MemoryAtom]:
+        if settlement.canonical_uuid:
+            atom = self._atom_cache.get_atom_by_uuid(settlement.canonical_uuid)
+            if atom is not None:
+                return atom
+        if settlement.canonical_alias:
+            return self._atom_cache.get_atom_by_alias(settlement.canonical_alias)
+        return None
 
     async def _cold_lookup(
         self,

--- a/src/hivememory/alice/runtime/resolver.py
+++ b/src/hivememory/alice/runtime/resolver.py
@@ -1,0 +1,155 @@
+"""
+RuntimeAliasResolver - 统一三级别名解析层。
+
+解析优先级:
+  L0: PendingAtomCache (运行时 pending atom)
+  L1: KoakumaAtomCache (会话级正式 atom 缓存)
+  L2: Storage (冷查询长期存储)
+
+作者: HiveMemory Team
+版本: 1.0
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Optional
+from uuid import UUID
+
+from hivememory.alice.runtime.cache import PendingAtomCache
+from hivememory.alice.runtime.models import PendingAtom
+from hivememory.core.models import MemoryAtom
+from hivememory.core.mtp.exceptions import (
+    BusRouteUnavailableError,
+    StorageOfflineError,
+    StorageReadError,
+)
+
+if TYPE_CHECKING:
+    from hivememory.alice.runtime.bus import AliceBus
+    from hivememory.alice.runtime.cache import KoakumaAtomCache
+    from hivememory.alice.runtime.models import MTPExecutionContext
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ResolveResult:
+    """别名解析结果。"""
+
+    kind: Literal["pending", "atom", "not_found"]
+    pending: Optional[PendingAtom] = field(default=None)
+    atom: Optional[MemoryAtom] = field(default=None)
+
+
+class RuntimeAliasResolver:
+    """
+    统一三级别名解析器。
+
+    作为 Alice runtime 共享基础设施，协调 L0/L1/L2 三级缓存命中路径。
+    """
+
+    def __init__(
+        self,
+        pending_cache: PendingAtomCache,
+        atom_cache: "KoakumaAtomCache",
+        bus: "AliceBus",
+    ) -> None:
+        self._pending_cache = pending_cache
+        self._atom_cache = atom_cache
+        self._bus = bus
+
+    def is_pending(self, alias: str) -> bool:
+        """快速检查 alias 是否在 L0 pending cache 中。"""
+        return self._pending_cache.has(alias)
+
+    async def resolve(
+        self,
+        alias: str,
+        context: Optional["MTPExecutionContext"] = None,
+    ) -> ResolveResult:
+        """
+        三级解析 alias。
+
+        Returns:
+            ResolveResult: kind="pending" / "atom" / "not_found"
+        """
+        # L0: PendingAtomCache
+        pending = self._pending_cache.get(alias)
+        if pending is not None:
+            logger.debug(f"L0 pending cache hit: alias='{alias}'")
+            return ResolveResult(kind="pending", pending=pending)
+
+        # L1: KoakumaAtomCache
+        atom = self._atom_cache.get_atom_by_alias(alias)
+        if atom is not None:
+            logger.debug(f"L1 atom cache hit: alias='{alias}'")
+            return ResolveResult(kind="atom", atom=atom)
+
+        # L2: Storage cold lookup
+        atom = await self._cold_lookup(alias, context)
+        if atom is not None:
+            return ResolveResult(kind="atom", atom=atom)
+
+        return ResolveResult(kind="not_found")
+
+    async def _cold_lookup(
+        self,
+        alias: str,
+        context: Optional["MTPExecutionContext"] = None,
+    ) -> Optional[MemoryAtom]:
+        """L2 冷查询：通过 bus 查询存储层。"""
+        from hivememory.alice.runtime.models import MTPExecutionContext
+        from hivememory.system.contracts.routes import GlobalRoutes
+
+        try:
+            identity = (
+                context.identity
+                if context is not None
+                else MTPExecutionContext().identity
+            )
+            retrieval_response = await self._bus.request(
+                GlobalRoutes.PATCHOULI_MEMORY_RETRIEVE_BY_ALIASES,
+                aliases=[alias],
+                identity=identity,
+            )
+            memories = getattr(retrieval_response, "memories", []) or []
+            memory = memories[0] if memories else None
+            if memory is None:
+                logger.debug(f"L2 cold-lookup miss: alias='{alias}'")
+                return None
+
+            uuid_str = str(memory.id)
+            UUID(uuid_str)
+
+            self._atom_cache.ingest_atom(memory)
+            logger.debug(
+                f"L2 cold-lookup hit: alias='{alias}' -> {uuid_str}, cached"
+            )
+            return memory
+        except KeyError as e:
+            logger.error(f"L2 cold-lookup route unavailable: alias='{alias}', error={e}")
+            raise BusRouteUnavailableError(
+                "Memory storage service is not available."
+            ) from e
+        except (StorageOfflineError, StorageReadError):
+            raise
+        except Exception as e:
+            logger.error(
+                f"L2 cold-lookup infrastructure failure: alias='{alias}', error={e}"
+            )
+            raise StorageReadError(
+                "Memory storage encountered an error during alias lookup."
+            ) from e
+
+    @property
+    def atom_cache(self) -> "KoakumaAtomCache":
+        return self._atom_cache
+
+    @property
+    def pending_cache(self) -> PendingAtomCache:
+        return self._pending_cache
+
+
+__all__ = ["ResolveResult", "RuntimeAliasResolver"]

--- a/src/hivememory/core/mtp/models.py
+++ b/src/hivememory/core/mtp/models.py
@@ -114,6 +114,7 @@ class MTPResponse(BaseModel):
     execution_time_ms: float = Field(default=0.0, description="执行耗时 (毫秒)")
     write_focus: Optional[Any] = Field(default=None, exclude=True)
     update_focus: Optional[Any] = Field(default=None, exclude=True)
+    pending_alias: Optional[str] = Field(default=None, exclude=True)
 
 
 __all__ = [

--- a/src/hivememory/core/protocol/models.py
+++ b/src/hivememory/core/protocol/models.py
@@ -188,6 +188,10 @@ class MTPExecutionResult(BaseModel):
         default=None,
         description="UPDATE 指令产生的后处理聚焦信号",
     )
+    pending_alias: Optional[str] = Field(
+        default=None,
+        description="WRITE/UPDATE 生成的 pending alias",
+    )
 
 
 class ChatResult(BaseModel):
@@ -206,13 +210,17 @@ class ChatResult(BaseModel):
     total_iterations: int = Field(default=1, description="总生成轮次")
     # LoopExecutor 收集的结构化轮次事件（序列化为 dict 避免循环导入）
     turn_events: List[Any] = Field(default_factory=list, description="LoopExecutor 收集的 TurnEvent 列表")
-    write_focus: Optional[Any] = Field(
-        default=None,
+    write_focus: List[Any] = Field(
+        default_factory=list,
         description="本轮 Agent run 中最后一个 WRITE 后处理聚焦信号",
     )
-    update_focus: Optional[Any] = Field(
-        default=None,
+    update_focus: List[Any] = Field(
+        default_factory=list,
         description="本轮 Agent run 中最后一个 UPDATE 后处理聚焦信号",
+    )
+    pending_aliases: List[str] = Field(
+        default_factory=list,
+        description="本轮 Agent run 中生成的所有 pending alias",
     )
 
 
@@ -297,12 +305,12 @@ class InteractionPayload(BaseModel):
     )
 
     # 控制信号 (挂载在 Payload 上，而非独立传输)
-    write_focus: Optional[Any] = Field(
-        default=None,
+    write_focus: List[Any] = Field(
+        default_factory=list,
         description="WRITE 指令的核心素材 (WriteFocus)"
     )
-    update_focus: Optional[Any] = Field(
-        default=None,
+    update_focus: List[Any] = Field(
+        default_factory=list,
         description="UPDATE 指令的修改意图 (UpdateFocus)"
     )
 

--- a/src/hivememory/engines/generation/__init__.py
+++ b/src/hivememory/engines/generation/__init__.py
@@ -29,6 +29,8 @@ from hivememory.engines.generation.models import (
     GenerationRequest,
     UpdateFocus,
     MergeResult,
+    PendingAtomSettlement,
+    MemoryGenerationResult,
 )
 
 from hivememory.engines.generation.extractor import (
@@ -57,6 +59,8 @@ __all__ = [
     "GenerationRequest",
     "UpdateFocus",
     "MergeResult",
+    "PendingAtomSettlement",
+    "MemoryGenerationResult",
     # 记忆提取
     "LLMMemoryExtractor",
     "NoOpMemoryExtractor",

--- a/src/hivememory/engines/generation/engine.py
+++ b/src/hivememory/engines/generation/engine.py
@@ -21,7 +21,11 @@ from datetime import datetime
 
 from hivememory.infrastructure.storage import QdrantMemoryStore
 from hivememory.core.models import MemoryAtom, MetaData, IndexLayer, PayloadLayer, MemoryType, Identity
-from hivememory.engines.generation.models import ExtractedMemoryDraft, GenerationRequest, GenerationContext, WriteFocus, UpdateFocus, MergeResult
+from hivememory.engines.generation.models import (
+    ExtractedMemoryDraft, GenerationRequest, GenerationContext,
+    WriteFocus, UpdateFocus, MergeResult,
+    MemoryGenerationResult, PendingAtomSettlement,
+)
 from hivememory.engines.generation.generation_transcript_builder import GenerationTranscriptBuilder
 from hivememory.engines.generation.interfaces import (
     BaseMemoryExtractor,
@@ -80,7 +84,7 @@ class MemoryGenerationEngine:
 
         logger.info("MemoryGenerationEngine 初始化完成")
 
-    def process(self, request: GenerationRequest) -> List[MemoryAtom]:
+    def process(self, request: GenerationRequest) -> List[MemoryGenerationResult]:
         """
         处理对话片段，提取记忆原子 (三模式)
 
@@ -92,7 +96,7 @@ class MemoryGenerationEngine:
             request: GenerationRequest 对象
 
         Returns:
-            List[MemoryAtom]: 提取的记忆原子列表
+            List[MemoryGenerationResult]: 结构化生成结果列表
         """
         if not request.has_context and not request.is_write and not request.is_update:
             logger.debug("空生成上下文且无 write_focus/update_focus，跳过处理")
@@ -106,7 +110,7 @@ class MemoryGenerationEngine:
         else:
             return self._process_mode_a(request)
 
-    def _process_mode_a(self, request: GenerationRequest) -> List[MemoryAtom]:
+    def _process_mode_a(self, request: GenerationRequest) -> List[MemoryGenerationResult]:
         """
         Mode A: 被动观察模式 (默认)
 
@@ -130,10 +134,10 @@ class MemoryGenerationEngine:
             logger.info("[Mode A] LLM 判断对话无价值，跳过存储")
             return []
 
-        # Step 2-4: 查重 → 构建 → 持久化
+        # Step 2-4: 查重 → 构建 → 持久化 (Mode A 无 intent)
         return self._dedup_and_persist(draft, identity)
 
-    def _process_mode_b(self, request: GenerationRequest) -> List[MemoryAtom]:
+    def _process_mode_b(self, request: GenerationRequest) -> List[MemoryGenerationResult]:
         """
         Mode B: 主动响应模式 (WRITE 指令触发)
 
@@ -163,8 +167,12 @@ class MemoryGenerationEngine:
             logger.warning("[Mode B] LLM 提取失败，启用 fallback 直接构建草稿")
             draft = self._build_fallback_draft(focus)
 
-        # Step 2-4: 查重 → 构建 → 持久化
-        return self._dedup_and_persist(draft, identity)
+        # Step 2-4: 查重 → 构建 → 持久化 (携带 intent 追踪)
+        return self._dedup_and_persist(
+            draft, identity,
+            intent_id=focus.intent_id,
+            pending_alias=focus.pending_alias,
+        )
 
     def _build_fallback_draft(self, focus: WriteFocus) -> ExtractedMemoryDraft:
         """
@@ -187,7 +195,7 @@ class MemoryGenerationEngine:
             alias_suffix="",
         )
 
-    def _process_mode_c(self, request: GenerationRequest) -> List[MemoryAtom]:
+    def _process_mode_c(self, request: GenerationRequest) -> List[MemoryGenerationResult]:
         """
         Mode C: 合并更新模式 (UPDATE 指令触发)
 
@@ -199,14 +207,14 @@ class MemoryGenerationEngine:
         identity = request.identity
 
         # 从内存索引中获取原始记忆
-        existing = uf.existing_memory
+        existing = request.existing_memory
 
         if existing is None:
             logger.error("[Mode C] existing_memory 未注入，无法执行 UPDATE")
             return []
 
         logger.info(
-            f"[Mode C] UPDATE 合并: alias='{uf.target_alias}', "
+            f"[Mode C] UPDATE 合并: alias='{uf.base_alias}', "
             f"instruction='{uf.instruction[:50]}...'"
         )
 
@@ -221,7 +229,7 @@ class MemoryGenerationEngine:
                 "instruction": uf.instruction,
                 "new_content": uf.content or "",
                 "memory_title": existing.index.title,
-                "memory_alias": existing.index.alias or uf.target_alias,
+                "memory_alias": existing.index.alias or uf.base_alias,
                 "transcript": transcript,
             }
         )
@@ -231,8 +239,12 @@ class MemoryGenerationEngine:
             logger.warning("[Mode C] LLM 合并失败，启用 fallback")
             merge_result = self._build_update_fallback(uf, existing)
 
-        # Step 2: 版本历史 + 更新 + 持久化
-        return self._apply_update(existing, merge_result)
+        # Step 2: 版本历史 + 更新 + 持久化 (携带 intent 追踪)
+        return self._apply_update(
+            existing, merge_result,
+            intent_id=uf.intent_id,
+            pending_alias=uf.pending_alias,
+        )
 
     def _build_update_fallback(
         self, uf: UpdateFocus, existing: MemoryAtom
@@ -257,8 +269,12 @@ class MemoryGenerationEngine:
         return MergeResult(new_content=new_content, changelog=changelog)
 
     def _apply_update(
-        self, memory: MemoryAtom, result: MergeResult
-    ) -> List[MemoryAtom]:
+        self,
+        memory: MemoryAtom,
+        result: MergeResult,
+        intent_id: Optional[str] = None,
+        pending_alias: Optional[str] = None,
+    ) -> List[MemoryGenerationResult]:
         """
         执行版本历史追踪 + 内容更新 + 持久化
 
@@ -297,13 +313,28 @@ class MemoryGenerationEngine:
             f"[Mode C] UPDATE 完成: '{memory.index.title}' "
             f"v{memory.meta.version}, changelog='{result.changelog}'"
         )
-        return [memory]
+
+        return [MemoryGenerationResult(
+            intent_id=intent_id,
+            pending_alias=pending_alias,
+            atom=memory,
+            canonical_alias=memory.get_alias(),
+            canonical_uuid=str(memory.id),
+            duplicate_decision=None,
+            operation="updated",
+            settlement=self._build_settlement(
+                intent_id, pending_alias, "UPDATED", None,
+                memory,
+            ),
+        )]
 
     def _dedup_and_persist(
         self,
         draft: ExtractedMemoryDraft,
         identity: Identity,
-    ) -> List[MemoryAtom]:
+        intent_id: Optional[str] = None,
+        pending_alias: Optional[str] = None,
+    ) -> List[MemoryGenerationResult]:
         """
         查重 → 构建 → 持久化 (Mode A/B 共用)
         """
@@ -312,32 +343,104 @@ class MemoryGenerationEngine:
 
         # 根据决策执行操作
         if decision == DuplicateDecision.TOUCH:
-            # 仅更新访问时间
             logger.info("记忆重复，更新访问时间")
+
             self.storage.update_access_info(existing_memory.id)
-            return [existing_memory]
+
+            return [MemoryGenerationResult(
+                intent_id=intent_id,
+                pending_alias=pending_alias,
+                atom=existing_memory,
+                canonical_alias=existing_memory.get_alias(),
+                canonical_uuid=str(existing_memory.id),
+                duplicate_decision="TOUCH",
+                operation="touched",
+                settlement=self._build_settlement(
+                    intent_id, pending_alias, "TOUCHED", "TOUCH",
+                    existing_memory,
+                ),
+            )]
 
         elif decision == DuplicateDecision.UPDATE:
-            # 知识演化合并
             logger.info("记忆演化，合并内容")
-            merged_memory = self.deduplicator.merge_memory(existing_memory, draft)
 
-            # 重新生成向量
+            merged_memory = self.deduplicator.merge_memory(existing_memory, draft)
             self._save_memory(merged_memory)
-            return [merged_memory]
+
+            return [MemoryGenerationResult(
+                intent_id=intent_id,
+                pending_alias=pending_alias,
+                atom=merged_memory,
+                canonical_alias=merged_memory.get_alias(),
+                canonical_uuid=str(merged_memory.id),
+                duplicate_decision="UPDATE",
+                operation="merged",
+                settlement=self._build_settlement(
+                    intent_id, pending_alias, "MERGED", "UPDATE",
+                    merged_memory,
+                ),
+            )]
 
         elif decision == DuplicateDecision.CREATE:
-            # 创建新记忆
             logger.info("创建新记忆")
-            memory = self._draft_to_memory(draft, identity)
 
-            # 持久化
+            memory = self._draft_to_memory(draft, identity)
             self._save_memory(memory)
-            return [memory]
+
+            return [MemoryGenerationResult(
+                intent_id=intent_id,
+                pending_alias=pending_alias,
+                atom=memory,
+                canonical_alias=memory.get_alias(),
+                canonical_uuid=str(memory.id),
+                duplicate_decision="CREATE",
+                operation="created",
+                settlement=self._build_settlement(
+                    intent_id, pending_alias, "COMMITTED", "CREATE",
+                    memory,
+                ),
+            )]
 
         else:  # DISCARD
             logger.info("低质量重复，丢弃")
-            return []
+            return [MemoryGenerationResult(
+                intent_id=intent_id,
+                pending_alias=pending_alias,
+                atom=None,
+                duplicate_decision="DISCARD",
+                operation="discarded",
+                settlement=self._build_settlement(
+                    intent_id, pending_alias, "DISCARDED", "DISCARD",
+                    None,
+                ),
+                message="Low-quality duplicate, discarded.",
+            )]
+
+    def _build_settlement(
+        self,
+        intent_id: Optional[str],
+        pending_alias: Optional[str],
+        status: str,
+        decision: Optional[str],
+        atom: Optional[MemoryAtom],
+    ) -> Optional[PendingAtomSettlement]:
+        """构建 settlement 视图；无 intent 时返回 None。"""
+        if not intent_id or not pending_alias:
+            return None
+        canonical_alias = None
+        canonical_uuid = None
+        if atom is not None:
+            canonical_alias = atom.get_alias()
+            canonical_uuid = str(atom.id)
+        return PendingAtomSettlement(
+            pending_alias=pending_alias,
+            intent_id=intent_id,
+            status=status,
+            duplicate_decision=decision,
+            canonical_alias=canonical_alias,
+            canonical_uuid=canonical_uuid,
+            message=f"Pending atom '{pending_alias}' settled as {status}.",
+        )
 
     def _render_transcript(self, request: GenerationRequest) -> str:
         """

--- a/src/hivememory/engines/generation/models.py
+++ b/src/hivememory/engines/generation/models.py
@@ -2,7 +2,7 @@
 HiveMemory Generation 模块数据模型
 """
 from enum import Enum
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 from pydantic import BaseModel, Field
 
 from hivememory.core.models import Identity
@@ -72,11 +72,15 @@ class WriteFocus(BaseModel):
         reason: WRITE 指令的 reason 参数 (可选)
         title: WRITE 指令的 title 参数 (可选)
         identity: 当前身份标识
+        pending_alias: 运行时 pending alias (Phase 2)
+        intent_id: 系统内部写入意图 ID (Phase 2)
     """
     content: str
     reason: Optional[str] = None
     title: Optional[str] = None
     identity: Identity = Field(default_factory=Identity)
+    pending_alias: Optional[str] = None
+    intent_id: Optional[str] = None
 
 
 # ============ UPDATE 指令数据模型 ============
@@ -92,17 +96,19 @@ class UpdateFocus(BaseModel):
     Attributes:
         instruction: 修改指令 (必填，自然语言描述)
         content: 新素材 (选填，代码替换或文本追加)
-        target_uuid: 目标记忆 UUID (由 Koakuma 解析 alias 得到)
-        target_alias: 目标记忆 alias
-        existing_memory: 由 LibrarianCore 从 storage 加载后注入
+        base_uuid: 本次 revision 基于的正式记忆 UUID
+        base_alias: 本次 revision 基于的正式记忆 alias
         identity: 当前身份标识
+        pending_alias: 运行时 pending alias (Phase 2)
+        intent_id: 系统内部写入意图 ID (Phase 2)
     """
     instruction: str
     content: Optional[str] = None
-    target_uuid: str
-    target_alias: str
-    existing_memory: Optional[Any] = None
+    base_uuid: str
+    base_alias: str
     identity: Identity = Field(default_factory=Identity)
+    pending_alias: Optional[str] = None
+    intent_id: Optional[str] = None
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -169,6 +175,7 @@ class GenerationRequest(BaseModel):
         context: 结构化生成上下文
         write_focus: WRITE 指令的聚焦内容 (None 表示非 Mode B)
         update_focus: UPDATE 指令的聚焦内容 (None 表示非 Mode C)
+        existing_memory: UPDATE 目标正式记忆，由 LibrarianCore 在构建请求时注入
     """
     context: GenerationContext = Field(
         default_factory=lambda: GenerationContext(),
@@ -176,6 +183,7 @@ class GenerationRequest(BaseModel):
     )
     write_focus: Optional[WriteFocus] = None
     update_focus: Optional[UpdateFocus] = None
+    existing_memory: Optional[Any] = None
 
     @property
     def is_write(self) -> bool:
@@ -214,6 +222,50 @@ class GenerationRequest(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
 
+# ============ Phase 2: Settlement 数据模型 ============
+
+class PendingAtomSettlement(BaseModel):
+    """
+    Pending intent 的结算视图。
+
+    由 GenerationEngine 在生成完成后产出，通过 GlobalSystemBus 回填到 AliceRuntime。
+    只有 MTP WRITE/UPDATE 触发的主动写入链路（携带 intent_id）才会生成 settlement。
+    """
+    pending_alias: str
+    intent_id: str
+    status: Literal["COMMITTED", "MERGED", "UPDATED", "TOUCHED", "DISCARDED", "FAILED"]
+    duplicate_decision: Optional[Literal["CREATE", "UPDATE", "TOUCH", "DISCARD"]] = None
+    canonical_alias: Optional[str] = None
+    canonical_uuid: Optional[str] = None
+    message: str = ""
+    error: Optional[str] = None
+    reason: Optional[str] = None
+
+
+class MemoryGenerationResult(BaseModel):
+    """
+    单次记忆生成操作的结构化结果。
+
+    替代原有 List[MemoryAtom] 返回值，携带 intent 追踪和 settlement 信息。
+    被动生成（Mode A）中 intent_id/pending_alias/settlement 均为 None。
+    """
+    intent_id: Optional[str] = None
+    pending_alias: Optional[str] = None
+
+    atom: Optional[Any] = None
+    canonical_alias: Optional[str] = None
+    canonical_uuid: Optional[str] = None
+
+    duplicate_decision: Optional[Literal["CREATE", "UPDATE", "TOUCH", "DISCARD"]] = None
+    operation: Literal["created", "merged", "touched", "discarded", "updated", "failed"]
+
+    settlement: Optional[PendingAtomSettlement] = None
+    message: Optional[str] = None
+    error: Optional[str] = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
 __all__ = [
     "ExtractedMemoryDraft",
     "DuplicateDecision",
@@ -223,4 +275,6 @@ __all__ = [
     "GenerationRequest",
     "GenerationTurn",
     "GenerationContext",
+    "PendingAtomSettlement",
+    "MemoryGenerationResult",
 ]

--- a/src/hivememory/engines/perception/semantic_flow_perception_layer.py
+++ b/src/hivememory/engines/perception/semantic_flow_perception_layer.py
@@ -213,23 +213,27 @@ class SemanticFlowPerceptionLayer(BasePerceptionLayer):
         )
 
         # 计算 priority
-        is_urgent = (payload.write_focus is not None or payload.update_focus is not None)
+        write_focuses = payload.write_focus
+        update_focuses = payload.update_focus
+        is_urgent = bool(write_focuses or update_focuses)
         # 3. 信号检查
         if is_urgent:
-            # URGENT: 添加 block → 立即 flush
+            # URGENT: 添加 block -> 立即 flush
             block.priority = "URGENT"
             self._buffer_manager.add_block(topic_id, block)
-            reason = (
-                FlushReason.MTP_WRITE if payload.write_focus is not None
-                else FlushReason.MTP_UPDATE
-            )
 
-            # 调用统一调度器
-            await self._trigger_manager.resolve_topic(
-                topic_id=topic_id,
-                trigger_reason=reason,
-                mtp_focus=payload.write_focus or payload.update_focus,
-            )
+            for focus in write_focuses:
+                await self._trigger_manager.resolve_topic(
+                    topic_id=topic_id,
+                    trigger_reason=FlushReason.MTP_WRITE,
+                    mtp_focus=focus,
+                )
+            for focus in update_focuses:
+                await self._trigger_manager.resolve_topic(
+                    topic_id=topic_id,
+                    trigger_reason=FlushReason.MTP_UPDATE,
+                    mtp_focus=focus,
+                )
         else:
             # NORMAL: 话题路由已由 TheEye 完成，直接添加 block
             self._buffer_manager.add_block(topic_id, block)

--- a/src/hivememory/patchouli/contracts/__init__.py
+++ b/src/hivememory/patchouli/contracts/__init__.py
@@ -1,2 +1,9 @@
+from hivememory.patchouli.contracts.local_events import PatchouliLocalEvents
 from hivememory.patchouli.contracts.local_routes import PatchouliLocalRoutes
 from hivememory.patchouli.contracts.public_routes import PatchouliRoutes
+
+__all__ = [
+    "PatchouliLocalEvents",
+    "PatchouliLocalRoutes",
+    "PatchouliRoutes",
+]

--- a/src/hivememory/patchouli/contracts/local_events.py
+++ b/src/hivememory/patchouli/contracts/local_events.py
@@ -1,0 +1,10 @@
+"""Patchouli subsystem-local pub/sub event names."""
+
+
+class PatchouliLocalEvents:
+    """Events published on PatchouliBus inside the Patchouli subsystem."""
+
+    PENDING_ATOM_SETTLED = "patchouli.events.pending_atom.settled"
+
+
+__all__ = ["PatchouliLocalEvents"]

--- a/src/hivememory/patchouli/runtime/core.py
+++ b/src/hivememory/patchouli/runtime/core.py
@@ -426,6 +426,7 @@ class PatchouliRuntime:
 
         self._services["librarian"] = LibrarianCore(
             storage=self.storage,
+            bus=self._local_bus,
             lifecycle_engine=self._engines["lifecycle"],
             perception_layer=self._engines["perception"],
             generation_engine=self._engines["generation"],

--- a/src/hivememory/patchouli/services/librarian.py
+++ b/src/hivememory/patchouli/services/librarian.py
@@ -26,6 +26,7 @@ from hivememory.engines.perception.models import FlushReason, ArchivePayload
 from hivememory.engines.generation.models import GenerationRequest, GenerationContext
 from hivememory.engines.generation.generation_transcript_builder import GenerationTranscriptBuilder
 from hivememory.infrastructure.storage import QdrantMemoryStore
+from hivememory.patchouli.contracts.local_events import PatchouliLocalEvents
 from hivememory.core.protocol.models import InteractionPayload
 
 if TYPE_CHECKING:
@@ -195,12 +196,12 @@ class LibrarianCore:
             elif reason == FlushReason.MTP_UPDATE and update_focus is not None:
                 logger.info(
                     f"LibrarianCore 处理 MTP_UPDATE flush: "
-                    f"alias='{update_focus.target_alias}', "
+                    f"alias='{update_focus.base_alias}', "
                     f"{len(gen_context.turns)} 轮对话上下文"
                 )
                 # 加载目标记忆
                 from uuid import UUID as _UUID
-                existing_result = self.storage.get_memory(_UUID(update_focus.target_uuid))
+                existing_result = self.storage.get_memory(_UUID(update_focus.base_uuid))
                 existing = (
                     await existing_result
                     if inspect.isawaitable(existing_result)
@@ -208,13 +209,13 @@ class LibrarianCore:
                 )
                 if existing is None:
                     logger.error(
-                        f"UPDATE 目标记忆不存在: {update_focus.target_uuid}"
+                        f"UPDATE 目标记忆不存在: {update_focus.base_uuid}"
                     )
                     return
-                update_focus.existing_memory = existing
                 request = GenerationRequest(
                     context=gen_context,
                     update_focus=update_focus,
+                    existing_memory=existing,
                 )
             else:
                 # Mode A: 普通记忆提取
@@ -226,7 +227,7 @@ class LibrarianCore:
             # 直接调用生成引擎
             if self.generation_engine:
                 process_result = self.generation_engine.process(request)
-                memories = (
+                results = (
                     await process_result
                     if inspect.isawaitable(process_result)
                     else process_result
@@ -235,10 +236,28 @@ class LibrarianCore:
                 logger.warning("generation_engine 未注入，跳过记忆生成")
                 return
 
+            memories = [r.atom for r in results if r.atom is not None]
+
             if memories:
                 logger.info(f"成功提取 {len(memories)} 条记忆")
             else:
                 logger.info("未提取到记忆（对话可能无价值或被过滤）")
+
+            # Phase 2: 发布 settlement 事件到 Patchouli local bus。
+            # 跨子系统转发由 PatchouliSystem 边界层负责。
+            if self._bus is not None:
+                for r in results:
+                    if r.settlement is not None:
+                        try:
+                            await self._bus.publish(
+                                PatchouliLocalEvents.PENDING_ATOM_SETTLED,
+                                settlement=r.settlement,
+                            )
+                        except Exception as pub_err:
+                            logger.warning(
+                                f"Settlement publish failed for "
+                                f"{r.settlement.pending_alias}: {pub_err}"
+                            )
 
         except Exception as e:
             logger.error(f"感知层 Flush 处理失败: {e}", exc_info=True)

--- a/src/hivememory/patchouli/system.py
+++ b/src/hivememory/patchouli/system.py
@@ -30,6 +30,7 @@ import logging
 
 from typing import TYPE_CHECKING, Any, Optional
 
+from hivememory.patchouli.contracts.local_events import PatchouliLocalEvents
 from hivememory.patchouli.contracts.public_routes import PatchouliRoutes
 from hivememory.patchouli.eye import TheEye
 from hivememory.patchouli.runtime import PatchouliRuntime
@@ -37,6 +38,7 @@ from hivememory.patchouli.services.librarian import LibrarianCore
 from hivememory.patchouli.services.retrieval import RetrievalFamiliar
 from hivememory.patchouli.service import PatchouliService
 from hivememory.system.config import HiveMemoryConfig
+from hivememory.system.contracts.events import GlobalEvents
 from hivememory.system.contracts.subsystem import SubsystemProtocol
 from hivememory.system.runtime.bus.global_bus import GlobalSystemBus
 from hivememory.system.runtime.scheduler.models import MaintenanceTaskSpec
@@ -92,6 +94,7 @@ class PatchouliSystem(SubsystemProtocol):
         self._scheduler = scheduler
         self._public_routes_registered = False
         self._maintenance_registered = False
+        self._local_events_registered = False
 
         logger.info("PatchouliSystem 帕秋莉系统初始化完成")
 
@@ -190,6 +193,10 @@ class PatchouliSystem(SubsystemProtocol):
         if not self.runtime.local_routes_registered:
             self.runtime.mount_local_routes(self.service)
 
+        if self._global_bus and not self._local_events_registered:
+            self._register_local_event_bridges()
+            self._local_events_registered = True
+
         if self._global_bus and not self._public_routes_registered:
             self._register_public_routes()
             self._public_routes_registered = True
@@ -209,6 +216,10 @@ class PatchouliSystem(SubsystemProtocol):
         if self._global_bus and self._public_routes_registered:
             self._unregister_public_routes()
             self._public_routes_registered = False
+
+        if self._global_bus and self._local_events_registered:
+            self._unregister_local_event_bridges()
+            self._local_events_registered = False
 
         self.runtime.unmount_local_routes()
 
@@ -272,6 +283,26 @@ class PatchouliSystem(SubsystemProtocol):
         self._global_bus.unregister(PatchouliRoutes.CLEANUP_PREPARED_AGENT_RUN)
         self._global_bus.unregister(PatchouliRoutes.MANUAL_ARCHIVE_TOPIC)
         self._global_bus.unregister(PatchouliRoutes.RECORD_MEMORY_CITATION)
+
+    def _register_local_event_bridges(self) -> None:
+        self.runtime.local_bus.subscribe(
+            PatchouliLocalEvents.PENDING_ATOM_SETTLED,
+            self._forward_pending_atom_settled,
+        )
+
+    def _unregister_local_event_bridges(self) -> None:
+        self.runtime.local_bus.unsubscribe(
+            PatchouliLocalEvents.PENDING_ATOM_SETTLED,
+            self._forward_pending_atom_settled,
+        )
+
+    async def _forward_pending_atom_settled(self, *, settlement) -> None:
+        if self._global_bus is None:
+            return
+        await self._global_bus.publish(
+            GlobalEvents.PENDING_ATOM_SETTLED,
+            settlement=settlement,
+        )
 
 
 __all__ = [

--- a/src/hivememory/prompts/mtp.py
+++ b/src/hivememory/prompts/mtp.py
@@ -46,8 +46,8 @@ _VERB_DEFS_EN = {
     "SEARCH": 'Discover unknown memories. Target=`*`. Args: `query="..."`, optional `filter="type:CODE"` (types: CODE, FACT, URL, REFLECTION, PROFILE, WIP).',
     "READ": "Fetch full content. Target=`alias` or `[alias1, alias2]` (use LIST for batching).",
     "RUN": 'Execute a kernel tool. Target=`tool_alias`. Args: `key="value"`.',
-    "WRITE": "Save valuable insights. Target=`*`. Args: `title=\"...\" content=`...``.",
-    "UPDATE": "Patch existing memory. Target=`alias`. Args: `patch=`...``.",
+    "WRITE": 'Save valuable insights. Target=`*`. Args: `title="..." content=`...``. Returns a pending alias (draft_*) readable immediately via READ.',
+    "UPDATE": 'Patch existing memory. Target=`alias`. Args: `instruction="..."`. Returns a pending alias (rev_*) readable immediately via READ.',
     "CALL": 'Delegate to a sub-agent. Target=`agent_alias` (from Available Sub-Agents list). Args: `topic="..."`, optional `context_refs="[alias1, alias2]"` to share memories.',
 }
 
@@ -55,8 +55,8 @@ _VERB_DEFS_ZH = {
     "SEARCH": '发现未知记忆。Target=`*`。参数: `query="..."`，可选 `filter="type:CODE"` (类型: CODE, FACT, URL, REFLECTION, PROFILE, WIP)。',
     "READ": "获取完整内容。Target=`alias` 或 `[alias1, alias2]` (使用列表批量读取)。",
     "RUN": '执行内核工具。Target=`tool_alias`。参数: `key="value"`。',
-    "WRITE": "保存有价值的洞察。Target=`*`。参数: `title=\"...\" content=`...``。",
-    "UPDATE": "修正已有记忆。Target=`alias`。参数: `patch=`...``。",
+    "WRITE": '保存有价值的洞察。Target=`*`。参数: `title="..." content=`...``。返回运行时 pending alias (draft_*)，可立即 READ。',
+    "UPDATE": '修正已有记忆。Target=`alias`。参数: `instruction="..."`。返回运行时 pending alias (rev_*)，可立即 READ。',
     "CALL": '委托子代理执行专项任务。Target=`agent_alias` (来自可用子代理列表)。参数: `topic="..."`，可选 `context_refs="[alias1, alias2]"` 共享记忆。',
 }
 
@@ -91,7 +91,8 @@ _BEHAVIORAL_GUIDELINES_EN = """\
 - Verify First: If asked about specific facts, code, or configurations, SEARCH/READ memory first. Do not guess.
 - Batch Operations: Always group multiple READ requests into one list `[a, b, c]` to save IO cycles.
 - Inline Flow: Execute protocol commands as part of your thought process. Do not stop to ask for permission.
-- Delegate to Sub-Agents: When the memory context lists Available Sub-Agents and the task matches their specialty, issue CALL to delegate instead of handling it yourself. Pass relevant memory aliases via `context_refs` to share context."""
+- Delegate to Sub-Agents: When the memory context lists Available Sub-Agents and the task matches their specialty, issue CALL to delegate instead of handling it yourself. Pass relevant memory aliases via `context_refs` to share context.
+- Pending Aliases: After WRITE/UPDATE, the system returns a pending alias (draft_* or rev_*). You can READ it immediately to verify. Pending aliases are runtime handles, not permanent memory aliases."""
 
 _DENSE_DEMO_EN = """\
 [ONE-SHOT DEMONSTRATION]
@@ -160,7 +161,8 @@ _BEHAVIORAL_GUIDELINES_ZH = """\
 - 先验证: 当被问及具体事实、代码或配置时，先 SEARCH/READ 记忆。不要猜测。
 - 批量操作: 将多个 READ 请求合并为一个列表 `[a, b, c]`，节省 IO 开销。
 - 行内执行: 将协议指令作为思考过程的一部分执行，不要停下来请求许可。
-- 优先委托: 若记忆上下文中列出了可用子代理，且任务契合其专项能力，应优先使用 CALL 委托子代理执行，而非自行承担。可通过 `context_refs` 传递相关记忆别名以共享上下文。"""
+- 优先委托: 若记忆上下文中列出了可用子代理，且任务契合其专项能力，应优先使用 CALL 委托子代理执行，而非自行承担。可通过 `context_refs` 传递相关记忆别名以共享上下文。
+- 运行时句柄: WRITE/UPDATE 后系统返回 pending alias (draft_* 或 rev_*)。可立即 READ 验证。Pending alias 是运行时句柄，非永久记忆别名。"""
 
 _DENSE_DEMO_ZH = """\
 [示例演示]

--- a/src/hivememory/system/application/passive/message_turn_buffer.py
+++ b/src/hivememory/system/application/passive/message_turn_buffer.py
@@ -216,8 +216,6 @@ class MessageTurnBuffer:
             assistant_final_text=assistant_final_text or None,
             turn_events=list(self._turn_events),
             mtp_traces=[],
-            write_focus=None,
-            update_focus=None,
             identity=self._identity,
             rewritten_query=(
                 self._gaze_result.rewritten_query if self._gaze_result else None

--- a/src/hivememory/system/contracts/events.py
+++ b/src/hivememory/system/contracts/events.py
@@ -15,3 +15,8 @@ class SystemEvent:
     event_type: SystemEventType
     subsystem_name: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class GlobalEvents:
+    """Global pub/sub event names for GlobalSystemBus."""
+    PENDING_ATOM_SETTLED = "alice.events.pending_atom.settled"

--- a/src/hivememory/system/runtime/bus/async_bus.py
+++ b/src/hivememory/system/runtime/bus/async_bus.py
@@ -54,8 +54,10 @@ class AsyncSystemBus:
     def unsubscribe(self, event: str, callback: Callable[..., Awaitable[None]]) -> None:
         if event in self._subscribers:
             self._subscribers[event] = [
-                cb for cb in self._subscribers[event] if cb is not callback
+                cb for cb in self._subscribers[event] if cb != callback
             ]
+            if not self._subscribers[event]:
+                self._subscribers.pop(event, None)
 
     async def publish(self, event: str, *args: Any, **kwargs: Any) -> None:
         subscribers = self._subscribers.get(event, [])

--- a/tests/integration/test_generation.py
+++ b/tests/integration/test_generation.py
@@ -162,7 +162,10 @@ class TestMemoryGenerationEngineLogic:
         result = self.engine.process(GenerationRequest(context=self._context_from_messages(self.messages)))
         
         assert len(result) == 1
-        assert result[0].index.title == "Test"
+        assert result[0].operation == "created"
+        assert result[0].duplicate_decision == "CREATE"
+        assert result[0].atom is not None
+        assert result[0].atom.index.title == "Test"
         
         # 验证存储调用
         self.mock_storage.upsert_memory.assert_called_once()
@@ -175,7 +178,9 @@ class TestMemoryGenerationEngineLogic:
         result = self.engine.process(GenerationRequest(context=self._context_from_messages(self.messages)))
         
         assert len(result) == 1
-        assert result[0] == self.memory_atom
+        assert result[0].operation == "touched"
+        assert result[0].duplicate_decision == "TOUCH"
+        assert result[0].atom == self.memory_atom
         
         # 验证只更新访问信息，不重新插入
         self.mock_storage.update_access_info.assert_called_once_with(self.memory_atom.id)
@@ -194,7 +199,10 @@ class TestMemoryGenerationEngineLogic:
         result = self.engine.process(GenerationRequest(context=self._context_from_messages(self.messages)))
         
         assert len(result) == 1
-        assert result[0].index.title == "Merged Title"
+        assert result[0].operation == "merged"
+        assert result[0].duplicate_decision == "UPDATE"
+        assert result[0].atom is not None
+        assert result[0].atom.index.title == "Merged Title"
         
         # 验证调用了合并和存储
         self.mock_deduplicator.merge_memory.assert_called_once()
@@ -207,7 +215,10 @@ class TestMemoryGenerationEngineLogic:
         self.mock_deduplicator.check_duplicate.return_value = (DuplicateDecision.DISCARD, None)
         
         result = self.engine.process(GenerationRequest(context=self._context_from_messages(self.messages)))
-        assert result == []
+        assert len(result) == 1
+        assert result[0].operation == "discarded"
+        assert result[0].duplicate_decision == "DISCARD"
+        assert result[0].atom is None
         self.mock_storage.upsert_memory.assert_not_called()
 
     def test_draft_to_memory_conversion(self):
@@ -273,7 +284,9 @@ class TestEngineComponentCoordination:
 
         assert result is not None
         assert len(result) == 1
-        assert result[0].index.title == "测试记忆"
+        assert result[0].operation == "created"
+        assert result[0].atom is not None
+        assert result[0].atom.index.title == "测试记忆"
         
         # 验证组件被正确调用
         mock_llm.complete_with_retry.assert_called()

--- a/tests/unit/alice/runtime/syscalls/conftest.py
+++ b/tests/unit/alice/runtime/syscalls/conftest.py
@@ -7,7 +7,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from hivememory.system.config import KoakumaConfig
+from hivememory.alice.runtime.cache import KoakumaAtomCache, PendingAtomCache
 from hivememory.alice.runtime.koakuma import KoakumaRuntime
+from hivememory.alice.runtime.resolver import RuntimeAliasResolver
 from hivememory.core.protocol.models import MTPExecutionResult
 from hivememory.prompts.mtp import MTPPromptBuilder
 from hivememory.system.contracts.routes import GlobalRoutes
@@ -69,9 +71,26 @@ def make_mock_bus(mock_storage: Optional[MagicMock] = None, mock_retrieval: Opti
     return MockAsyncBus(mock_storage=mock_storage, mock_retrieval=mock_retrieval, mock_generation=mock_generation)
 
 
+def make_runtime_alias_resolver(bus: MockAsyncBus) -> RuntimeAliasResolver:
+    return RuntimeAliasResolver(
+        pending_cache=PendingAtomCache(),
+        atom_cache=KoakumaAtomCache(),
+        bus=bus,
+    )
+
+
+def make_koakuma_runtime(bus: MockAsyncBus, config=None) -> KoakumaRuntime:
+    return KoakumaRuntime(
+        bus=bus,
+        config=config or KoakumaConfig(),
+        alias_resolver=make_runtime_alias_resolver(bus),
+    )
+
+
 @pytest.fixture
 def koakuma() -> KoakumaRuntime:
-    return KoakumaRuntime(bus=make_mock_bus(), config=KoakumaConfig())
+    bus = make_mock_bus()
+    return make_koakuma_runtime(bus, KoakumaConfig())
 
 
 @pytest.fixture

--- a/tests/unit/alice/runtime/syscalls/test_mtp_integration.py
+++ b/tests/unit/alice/runtime/syscalls/test_mtp_integration.py
@@ -102,7 +102,7 @@ class TestFileIOViaMTP:
     @pytest.fixture
     def workspace(self):
         ws = Path.cwd() / ".test_tmp" / f"hivememory-mtp-{uuid4().hex}"
-        ws.mkdir()
+        ws.mkdir(parents=True)
         try:
             yield ws
         finally:

--- a/tests/unit/alice/runtime/syscalls/test_mtp_integration.py
+++ b/tests/unit/alice/runtime/syscalls/test_mtp_integration.py
@@ -110,11 +110,11 @@ class TestFileIOViaMTP:
 
     @pytest.fixture
     def file_koakuma(self, workspace):
-        from .conftest import make_mock_bus
+        from .conftest import make_koakuma_runtime, make_mock_bus
         bus = make_mock_bus()
-        return KoakumaRuntime(
-            bus=bus,
-            config=KoakumaConfig(workspace_path=str(workspace)),
+        return make_koakuma_runtime(
+            bus,
+            KoakumaConfig(workspace_path=str(workspace)),
         )
 
     def test_read_file_via_mtp(self, file_koakuma, workspace):

--- a/tests/unit/alice/runtime/test_agent_runtime.py
+++ b/tests/unit/alice/runtime/test_agent_runtime.py
@@ -2,6 +2,8 @@
 
 from hivememory.alice.runtime.agent.runtime import AgentRuntime
 from hivememory.alice.runtime.bus import AliceBus
+from hivememory.alice.runtime.cache import KoakumaAtomCache, PendingAtomCache
+from hivememory.alice.runtime.resolver import RuntimeAliasResolver
 from hivememory.prompts.assembler import AgentPromptAssembler
 from hivememory.system.config import HiveMemoryConfig
 
@@ -11,16 +13,23 @@ def test_agent_runtime_uses_injected_dependencies():
     local_bus = AliceBus()
     prompt_assembler = AgentPromptAssembler(config.koakuma)
     mtp_executor = MagicMock()
+    alias_resolver = RuntimeAliasResolver(
+        pending_cache=PendingAtomCache(),
+        atom_cache=KoakumaAtomCache(),
+        bus=local_bus,
+    )
 
     runtime = AgentRuntime(
         local_bus=local_bus,
         prompt_assembler=prompt_assembler,
         mtp_executor=mtp_executor,
         config=config,
+        alias_resolver=alias_resolver,
     )
 
     assert runtime._mtp_executor is mtp_executor
     assert runtime._loop_executor._local_bus is local_bus
     assert runtime._loop_executor._mtp_executor is mtp_executor
+    assert runtime._loop_executor._alias_resolver is alias_resolver
     assert runtime._frame_scheduler._prompt_assembler is prompt_assembler
 

--- a/tests/unit/alice/runtime/test_mtp_executor.py
+++ b/tests/unit/alice/runtime/test_mtp_executor.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from hivememory.alice.runtime.models import MTPExecutionContext
+from hivememory.alice.runtime.models import MTPExecutionContext, RuntimeScope
 from hivememory.alice.runtime.agent.mtp_executor import KoakumaMTPExecutor
 from hivememory.core.models import Identity, OMNI_DOLL_PROFILE
 from hivememory.core.protocol.models import MTPExecutionResult
@@ -23,7 +23,7 @@ async def test_koakuma_mtp_executor_delegates_to_runtime():
     context = MTPExecutionContext(
         identity=Identity(user_id="u1", agent_id="agent_a"),
         agent_profile=OMNI_DOLL_PROFILE,
-        depth=0,
+        runtime_scope=RuntimeScope(depth=0),
     )
 
     executor = KoakumaMTPExecutor(koakuma)

--- a/tests/unit/engines/generation/test_engine.py
+++ b/tests/unit/engines/generation/test_engine.py
@@ -139,16 +139,19 @@ class TestGenerationEngineRouting:
         existing = _make_memory()
         uf = UpdateFocus(
             instruction="添加错误处理",
-            target_uuid=str(existing.id),
-            target_alias="fact_test",
-            existing_memory=existing,
+            base_uuid=str(existing.id),
+            base_alias="fact_test",
             identity=_make_identity(),
         )
         merge_result = MergeResult(new_content="新内容", changelog="添加了错误处理")
         self.mock_extractor.merge.return_value = merge_result
         self.mock_storage.upsert_memory = Mock()
 
-        request = GenerationRequest(context=GenerationContext(), update_focus=uf)
+        request = GenerationRequest(
+            context=GenerationContext(),
+            update_focus=uf,
+            existing_memory=existing,
+        )
         result = self.engine.process(request)
 
         self.mock_extractor.merge.assert_called_once()
@@ -180,7 +183,7 @@ class TestGenerationEngineModeA:
         result = self.engine.process(request)
 
         assert len(result) == 1
-        assert result[0].index.title == "测试记忆"
+        assert result[0].atom.index.title == "测试记忆"
 
     def test_mode_a_extract_no_value(self):
         """LLM 判断无价值返回空"""
@@ -249,7 +252,7 @@ class TestGenerationEngineModeB:
 
         # fallback 应保证内容不丢失
         assert len(result) == 1
-        assert result[0].payload.content == "重要内容不能丢"
+        assert result[0].atom.payload.content == "重要内容不能丢"
 
     def test_build_fallback_draft(self):
         """fallback 草稿构建逻辑"""
@@ -289,12 +292,15 @@ class TestGenerationEngineModeC:
         uf = UpdateFocus(
             instruction=instruction,
             content=content,
-            target_uuid=str(existing.id),
-            target_alias="fact_test",
-            existing_memory=existing,
+            base_uuid=str(existing.id),
+            base_alias="fact_test",
             identity=_make_identity(),
         )
-        return GenerationRequest(context=GenerationContext(), update_focus=uf)
+        return GenerationRequest(
+            context=GenerationContext(),
+            update_focus=uf,
+            existing_memory=existing,
+        )
 
     def test_mode_c_merge_success(self):
         """正常 UPDATE 合并流程"""
@@ -306,15 +312,14 @@ class TestGenerationEngineModeC:
         result = self.engine.process(request)
 
         assert len(result) == 1
-        assert result[0].payload.content == "合并后内容"
+        assert result[0].atom.payload.content == "合并后内容"
 
     def test_mode_c_no_existing_memory(self):
         """existing_memory=None 时返回空"""
         uf = UpdateFocus(
             instruction="更新",
-            target_uuid=str(uuid4()),
-            target_alias="fact_test",
-            existing_memory=None,
+            base_uuid=str(uuid4()),
+            base_alias="fact_test",
             identity=_make_identity(),
         )
         request = GenerationRequest(context=GenerationContext(), update_focus=uf)
@@ -332,7 +337,7 @@ class TestGenerationEngineModeC:
         result = self.engine.process(request)
 
         assert len(result) == 1
-        assert "追加内容" in result[0].payload.content
+        assert "追加内容" in result[0].atom.payload.content
 
     def test_mode_c_fallback_no_content(self):
         """fallback 仅有 instruction 无 content 时保留旧内容"""
@@ -344,7 +349,7 @@ class TestGenerationEngineModeC:
         result = self.engine.process(request)
 
         assert len(result) == 1
-        assert result[0].payload.content == "旧内容"
+        assert result[0].atom.payload.content == "旧内容"
 
     def test_apply_update_version_history(self):
         """版本历史追踪"""
@@ -355,7 +360,7 @@ class TestGenerationEngineModeC:
         result = self.engine._apply_update(existing, merge_result)
 
         assert len(result) == 1
-        mem = result[0]
+        mem = result[0].atom
         assert mem.payload.content == "新版本"
         assert mem.meta.version >= 2
         assert mem.meta.confidence_score == 1.0
@@ -386,7 +391,8 @@ class TestGenerationEngineDedup:
         result = self.engine._dedup_and_persist(draft, _make_identity())
 
         self.mock_storage.update_access_info.assert_called_once_with(existing.id)
-        assert result == [existing]
+        assert result[0].atom is existing
+        assert result[0].operation == "touched"
 
     def test_dedup_update(self):
         """UPDATE 决策合并内容并重新保存"""
@@ -401,7 +407,8 @@ class TestGenerationEngineDedup:
 
         self.mock_deduplicator.merge_memory.assert_called_once_with(existing, draft)
         self.mock_storage.upsert_memory.assert_called_once()
-        assert result == [merged]
+        assert result[0].atom is merged
+        assert result[0].operation == "merged"
 
     def test_dedup_create(self):
         """CREATE 决策创建新记忆"""
@@ -413,7 +420,7 @@ class TestGenerationEngineDedup:
 
         self.mock_storage.upsert_memory.assert_called_once()
         assert len(result) == 1
-        assert result[0].index.title == "测试记忆"
+        assert result[0].atom.index.title == "测试记忆"
 
     def test_dedup_discard(self):
         """DISCARD 决策返回空"""
@@ -422,7 +429,9 @@ class TestGenerationEngineDedup:
 
         result = self.engine._dedup_and_persist(draft, _make_identity())
 
-        assert result == []
+        assert len(result) == 1
+        assert result[0].atom is None
+        assert result[0].operation == "discarded"
         self.mock_storage.upsert_memory.assert_not_called()
 
 

--- a/tests/unit/engines/generation/test_generation_transcript_builder.py
+++ b/tests/unit/engines/generation/test_generation_transcript_builder.py
@@ -277,8 +277,8 @@ class TestGenerationRequestIdentity:
             context=ctx,
             update_focus=UpdateFocus(
                 instruction="update",
-                target_uuid="uuid-1",
-                target_alias="alias",
+                base_uuid="uuid-1",
+                base_alias="alias",
                 identity=_identity("update_agent"),
             ),
         )
@@ -293,8 +293,8 @@ class TestGenerationRequestIdentity:
             context=ctx,
             update_focus=UpdateFocus(
                 instruction="update",
-                target_uuid="uuid-1",
-                target_alias="alias",
+                base_uuid="uuid-1",
+                base_alias="alias",
                 identity=_identity("update_agent"),
             ),
             write_focus=WriteFocus(

--- a/tests/unit/patchouli/kernel/test_koakuma_permissions.py
+++ b/tests/unit/patchouli/kernel/test_koakuma_permissions.py
@@ -9,7 +9,10 @@ from hivememory.core.mtp.exceptions import AgentFault, PermissionDeniedError
 
 
 def _create_koakuma():
-    return KoakumaRuntime(bus=None, config=None)
+    from tests.unit.patchouli.mtp.conftest import make_koakuma_runtime, make_mock_bus
+
+    bus = make_mock_bus()
+    return make_koakuma_runtime(bus)
 
 
 def _make_profile(allowed_verbs=None, allowed_tools=None):

--- a/tests/unit/patchouli/kernel/test_librarian_core.py
+++ b/tests/unit/patchouli/kernel/test_librarian_core.py
@@ -241,8 +241,8 @@ class TestLibrarianCoreGenerateMemory:
         # 使用真正的 UpdateFocus 实例而不是 Mock
         update_focus = UpdateFocus(
             instruction="更新测试",
-            target_uuid=str(uuid4()),
-            target_alias="fact_test",
+            base_uuid=str(uuid4()),
+            base_alias="fact_test",
             identity=_make_identity(),
         )
         existing_memory = Mock()
@@ -260,16 +260,17 @@ class TestLibrarianCoreGenerateMemory:
 
         await self.core._on_generate_memory(payload)
 
-        assert update_focus.existing_memory is existing_memory
         self.mock_generation.process.assert_called_once()
+        request = self.mock_generation.process.call_args[0][0]
+        assert request.existing_memory is existing_memory
 
     @pytest.mark.asyncio
     async def test_generate_memory_mode_c_update_without_context_still_runs(self):
         """MTP_UPDATE 不应依赖上下文轮次，空背景也应进入 generation fallback"""
         update_focus = UpdateFocus(
             instruction="更新测试",
-            target_uuid=str(uuid4()),
-            target_alias="fact_test",
+            base_uuid=str(uuid4()),
+            base_alias="fact_test",
             identity=_make_identity(),
         )
         existing_memory = Mock()
@@ -289,7 +290,7 @@ class TestLibrarianCoreGenerateMemory:
         assert request.context is not None
         assert request.context.turns == []
         assert request.update_focus is update_focus
-        assert update_focus.existing_memory is existing_memory
+        assert request.existing_memory is existing_memory
 
     @pytest.mark.asyncio
     async def test_generate_memory_mode_c_update_memory_not_found(self):
@@ -298,8 +299,8 @@ class TestLibrarianCoreGenerateMemory:
         # 使用真正的 UpdateFocus 实例
         update_focus = UpdateFocus(
             instruction="更新测试",
-            target_uuid=str(uuid4()),
-            target_alias="fact_test",
+            base_uuid=str(uuid4()),
+            base_alias="fact_test",
             identity=_make_identity(),
         )
 

--- a/tests/unit/patchouli/kernel/test_loop_executor_stream.py
+++ b/tests/unit/patchouli/kernel/test_loop_executor_stream.py
@@ -14,7 +14,12 @@ import pytest
 
 from hivememory.core.models import Identity, OMNI_DOLL_PROFILE
 from hivememory.alice.runtime.cache import KoakumaAtomCache, PendingAtomCache
-from hivememory.alice.runtime.models import ExecutionFrame, GenerationResult, StreamChunk
+from hivememory.alice.runtime.models import (
+    ExecutionFrame,
+    GenerationResult,
+    RuntimeScope,
+    StreamChunk,
+)
 from hivememory.alice.runtime.agent.loop_executor import KernelLoopExecutor
 from hivememory.alice.runtime.resolver import RuntimeAliasResolver
 from hivememory.core.protocol.models import MTPExecutionResult
@@ -50,20 +55,17 @@ def _make_call_mtp_result() -> MTPExecutionResult:
 
 def _make_frames():
     main_frame = ExecutionFrame(
-        process_id="pid_main_test",
+        runtime_scope=RuntimeScope(frame_id="frame_main_test", depth=0),
         agent_profile=OMNI_DOLL_PROFILE,
         working_history=[{"role": "user", "content": "主任务"}],
-        depth=0,
         topic_id="topic_1",
         identity=Identity(user_id="u1", agent_id="omni_doll"),
     )
     sub_frame = ExecutionFrame(
-        process_id="pid_sub_test",
+        runtime_scope=main_frame.runtime_scope.for_child("frame_sub_test"),
         agent_profile=OMNI_DOLL_PROFILE,
         working_history=[{"role": "user", "content": "子任务"}],
-        depth=1,
         topic_id=None,
-        parent_frame_id=main_frame.process_id,
         identity=Identity(user_id="u1", agent_id="coder_doll"),
     )
     return main_frame, sub_frame

--- a/tests/unit/patchouli/kernel/test_loop_executor_stream.py
+++ b/tests/unit/patchouli/kernel/test_loop_executor_stream.py
@@ -13,8 +13,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from hivememory.core.models import Identity, OMNI_DOLL_PROFILE
+from hivememory.alice.runtime.cache import KoakumaAtomCache, PendingAtomCache
 from hivememory.alice.runtime.models import ExecutionFrame, GenerationResult, StreamChunk
 from hivememory.alice.runtime.agent.loop_executor import KernelLoopExecutor
+from hivememory.alice.runtime.resolver import RuntimeAliasResolver
 from hivememory.core.protocol.models import MTPExecutionResult
 
 
@@ -81,6 +83,11 @@ def _build_executor_with_stream(worker_stream_impl):
 
     worker_agent = MagicMock()
     worker_agent.generate_stream = worker_stream_impl
+    alias_resolver = RuntimeAliasResolver(
+        pending_cache=PendingAtomCache(),
+        atom_cache=KoakumaAtomCache(),
+        bus=kernel.local_bus,
+    )
 
     return KernelLoopExecutor(
         worker_agent=worker_agent,
@@ -89,6 +96,7 @@ def _build_executor_with_stream(worker_stream_impl):
         agent_profile_resolver=profile_resolver,
         mtp_executor=mtp_executor,
         config=kernel.config.agent_runtime,
+        alias_resolver=alias_resolver,
     ), kernel
 
 

--- a/tests/unit/patchouli/kernel/test_loop_executor_turn_events.py
+++ b/tests/unit/patchouli/kernel/test_loop_executor_turn_events.py
@@ -93,6 +93,7 @@ def _make_frame(depth: int = 0) -> ExecutionFrame:
         depth=depth,
         topic_id="topic_1",
         identity=Identity(user_id="u1", agent_id="agent_a"),
+        run_id="run_test_1",
     )
 
 
@@ -213,6 +214,8 @@ async def test_mtp_execution_receives_frame_context():
     assert isinstance(context, MTPExecutionContext)
     assert context.identity == frame.identity
     assert context.agent_profile is frame.agent_profile
+    assert context.run_id == frame.run_id
+    assert context.frame_id == frame.process_id
     assert context.depth == frame.depth
 
 

--- a/tests/unit/patchouli/kernel/test_loop_executor_turn_events.py
+++ b/tests/unit/patchouli/kernel/test_loop_executor_turn_events.py
@@ -338,6 +338,30 @@ async def test_context_refs_fetch_uses_runtime_alias_resolver():
     kernel.local_bus.request.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_context_refs_fetch_renders_redirected_alias_as_canonical_atom():
+    executor, kernel = _build_executor([])
+    atom = MagicMock()
+    atom.payload.content = "canonical ctx"
+    atom.get_alias.return_value = "fact_canonical"
+    resolved = MagicMock()
+    resolved.kind = "redirect"
+    resolved.atom = atom
+    resolved.pending = None
+    resolved.canonical_alias = "fact_canonical"
+    executor._alias_resolver.resolve = AsyncMock(return_value=resolved)
+    identity = Identity(user_id="u1", agent_id="agent_a")
+
+    result = await executor._fetch_context_refs_content(["draft_ctx_1234"], identity)
+
+    assert result == (
+        "[Shared Context from Parent Agent]\n\n"
+        "[fact_canonical]:\ncanonical ctx"
+    )
+    executor._alias_resolver.resolve.assert_awaited_once()
+    kernel.local_bus.request.assert_not_called()
+
+
 def test_chat_result_default_turn_events():
     """ChatResult 新字段有默认值，不破坏现有代码"""
     from hivememory.core.protocol.models import ChatResult

--- a/tests/unit/patchouli/kernel/test_loop_executor_turn_events.py
+++ b/tests/unit/patchouli/kernel/test_loop_executor_turn_events.py
@@ -18,6 +18,7 @@ from hivememory.alice.runtime.models import (
     ExecutionFrame,
     GenerationResult,
     MTPExecutionContext,
+    RuntimeScope,
 )
 from hivememory.core.models import Identity, OMNI_DOLL_PROFILE, TurnEvent
 from hivememory.core.protocol.models import MTPExecutionResult
@@ -87,13 +88,15 @@ def _call_mtp_exec_result() -> MTPExecutionResult:
 
 def _make_frame(depth: int = 0) -> ExecutionFrame:
     return ExecutionFrame(
-        process_id="test_pid",
+        runtime_scope=RuntimeScope(
+            run_id="run_test_1",
+            frame_id="test_frame",
+            depth=depth,
+        ),
         agent_profile=OMNI_DOLL_PROFILE,
         working_history=[{"role": "user", "content": "hello"}],
-        depth=depth,
         topic_id="topic_1",
         identity=Identity(user_id="u1", agent_id="agent_a"),
-        run_id="run_test_1",
     )
 
 
@@ -214,9 +217,10 @@ async def test_mtp_execution_receives_frame_context():
     assert isinstance(context, MTPExecutionContext)
     assert context.identity == frame.identity
     assert context.agent_profile is frame.agent_profile
-    assert context.run_id == frame.run_id
-    assert context.frame_id == frame.process_id
-    assert context.depth == frame.depth
+    assert context.runtime_scope.run_id == frame.runtime_scope.run_id
+    assert context.runtime_scope.frame_id == frame.runtime_scope.frame_id
+    assert context.runtime_scope.depth == frame.runtime_scope.depth
+    assert context.runtime_scope.action_id == "action_1_0"
 
 
 @pytest.mark.asyncio
@@ -269,12 +273,10 @@ async def test_call_path_produces_mtp_result_event_with_call_verb():
     """CALL 路径: 父 frame 产出 kind=tool_result, tool_kind=CALL, role=user"""
     main_frame = _make_frame(depth=0)
     sub_frame = ExecutionFrame(
-        process_id="sub_pid",
+        runtime_scope=main_frame.runtime_scope.for_child("sub_frame"),
         agent_profile=OMNI_DOLL_PROFILE,
         working_history=[{"role": "user", "content": "sub task"}],
-        depth=1,
         topic_id=None,
-        parent_frame_id=main_frame.process_id,
         identity=Identity(user_id="u1", agent_id="sub_agent"),
     )
 

--- a/tests/unit/patchouli/kernel/test_loop_executor_turn_events.py
+++ b/tests/unit/patchouli/kernel/test_loop_executor_turn_events.py
@@ -21,7 +21,6 @@ from hivememory.alice.runtime.models import (
 )
 from hivememory.core.models import Identity, OMNI_DOLL_PROFILE, TurnEvent
 from hivememory.core.protocol.models import MTPExecutionResult
-from hivememory.system.contracts.routes import GlobalRoutes
 
 
 def _natural_result(text: str) -> GenerationResult:
@@ -108,6 +107,7 @@ def _build_executor(generate_async_side_effect) -> tuple[KernelLoopExecutor, Mag
     profile_resolver.resolve = AsyncMock(return_value=OMNI_DOLL_PROFILE)
     mtp_executor = MagicMock()
     mtp_executor.intercept_and_execute = AsyncMock(return_value=None)
+    alias_resolver = MagicMock()
 
     worker_agent = MagicMock()
     worker_agent.generate_async = AsyncMock(side_effect=generate_async_side_effect)
@@ -119,6 +119,7 @@ def _build_executor(generate_async_side_effect) -> tuple[KernelLoopExecutor, Mag
         agent_profile_resolver=profile_resolver,
         mtp_executor=mtp_executor,
         config=kernel.config.agent_runtime,
+        alias_resolver=alias_resolver,
     )
     return executor, kernel
 
@@ -314,21 +315,22 @@ async def test_call_path_produces_mtp_result_event_with_call_verb():
 
 
 @pytest.mark.asyncio
-async def test_context_refs_fetch_uses_injected_local_bus_with_public_route():
+async def test_context_refs_fetch_uses_runtime_alias_resolver():
     executor, kernel = _build_executor([])
-    response = MagicMock()
-    response.rendered_context = "<memory_context>ctx</memory_context>"
-    kernel.local_bus.request = AsyncMock(return_value=response)
+    atom = MagicMock()
+    atom.payload.content = "ctx"
+    resolved = MagicMock()
+    resolved.kind = "atom"
+    resolved.atom = atom
+    resolved.pending = None
+    executor._alias_resolver.resolve = AsyncMock(return_value=resolved)
     identity = Identity(user_id="u1", agent_id="agent_a")
 
     result = await executor._fetch_context_refs_content(["fact_a"], identity)
 
-    assert result == "[Shared Context from Parent Agent]\n\n<memory_context>ctx</memory_context>"
-    kernel.local_bus.request.assert_awaited_once_with(
-        GlobalRoutes.PATCHOULI_MEMORY_RETRIEVE_BY_ALIASES,
-        ["fact_a"],
-        identity,
-    )
+    assert result == "[Shared Context from Parent Agent]\n\n[fact_a]:\nctx"
+    executor._alias_resolver.resolve.assert_awaited_once()
+    kernel.local_bus.request.assert_not_called()
 
 
 def test_chat_result_default_turn_events():

--- a/tests/unit/patchouli/kernel/test_runtime_alias_resolver.py
+++ b/tests/unit/patchouli/kernel/test_runtime_alias_resolver.py
@@ -1,0 +1,123 @@
+import pytest
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from hivememory.alice.runtime.cache import KoakumaAtomCache, PendingAtomCache
+from hivememory.alice.runtime.models import MTPExecutionContext
+from hivememory.alice.runtime.resolver import RuntimeAliasResolver
+from hivememory.core.models import (
+    Identity,
+    IndexLayer,
+    MemoryAtom,
+    MemoryType,
+    MetaData,
+    PayloadLayer,
+)
+from hivememory.core.mtp.exceptions import BusRouteUnavailableError, StorageReadError
+
+from tests.unit.patchouli.mtp.conftest import make_mock_bus
+
+
+def _make_memory(alias: str, content: str = "content") -> MemoryAtom:
+    return MemoryAtom(
+        id=uuid4(),
+        meta=MetaData(user_id="test_user", source_agent_id="test_agent"),
+        index=IndexLayer(
+            title="Test Memory",
+            summary="A resolver test memory",
+            tags=["test"],
+            memory_type=MemoryType.FACT,
+            alias=alias,
+        ),
+        payload=PayloadLayer(content=content),
+    )
+
+
+@pytest.fixture
+def resolver_parts():
+    bus = make_mock_bus()
+    pending_cache = PendingAtomCache()
+    atom_cache = KoakumaAtomCache()
+    resolver = RuntimeAliasResolver(
+        pending_cache=pending_cache,
+        atom_cache=atom_cache,
+        bus=bus,
+    )
+    return resolver, pending_cache, atom_cache, bus
+
+
+@pytest.mark.asyncio
+async def test_resolve_l0_pending_hit(resolver_parts):
+    resolver, pending_cache, _atom_cache, bus = resolver_parts
+    pending = pending_cache.register_write(
+        content="pending content",
+        title="Pending Note",
+        reason=None,
+        identity=Identity(user_id="test_user"),
+    )
+
+    result = await resolver.resolve(pending.pending_alias)
+
+    assert result.kind == "pending"
+    assert result.pending is pending
+    bus._mock_storage.get_memory_by_alias.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_l1_atom_hit(resolver_parts):
+    resolver, _pending_cache, atom_cache, bus = resolver_parts
+    atom = _make_memory(alias="fact_l1", content="from l1")
+    atom_cache.ingest_atom(atom)
+
+    result = await resolver.resolve("fact_l1")
+
+    assert result.kind == "atom"
+    assert result.atom is atom
+    bus._mock_storage.get_memory_by_alias.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_l2_hit_promotes_to_l1(resolver_parts):
+    resolver, _pending_cache, atom_cache, bus = resolver_parts
+    atom = _make_memory(alias="fact_l2", content="from l2")
+    bus._mock_storage.get_memory_by_alias.return_value = atom
+
+    context = MTPExecutionContext(identity=Identity(user_id="test_user"))
+    result = await resolver.resolve("fact_l2", context=context)
+
+    assert result.kind == "atom"
+    assert result.atom is atom
+    assert atom_cache.get_atom_by_alias("fact_l2") is atom
+
+    bus._mock_storage.get_memory_by_alias.reset_mock()
+    second = await resolver.resolve("fact_l2", context=context)
+    assert second.kind == "atom"
+    bus._mock_storage.get_memory_by_alias.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_l2_miss(resolver_parts):
+    resolver, _pending_cache, _atom_cache, bus = resolver_parts
+    bus._mock_storage.get_memory_by_alias.return_value = None
+
+    result = await resolver.resolve("missing")
+
+    assert result.kind == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_resolve_route_failure_raises_bus_unavailable(resolver_parts):
+    resolver, _pending_cache, _atom_cache, bus = resolver_parts
+    bus._mock_storage.get_memory_by_alias.side_effect = KeyError("route missing")
+
+    with pytest.raises(BusRouteUnavailableError):
+        await resolver.resolve("fact_route_missing")
+
+
+@pytest.mark.asyncio
+async def test_resolve_storage_failure_raises_storage_read_error(resolver_parts):
+    resolver, _pending_cache, _atom_cache, bus = resolver_parts
+    bus._mock_storage.get_memory_by_alias.side_effect = RuntimeError("boom")
+
+    with pytest.raises(StorageReadError):
+        await resolver.resolve("fact_boom")

--- a/tests/unit/patchouli/kernel/test_runtime_alias_resolver.py
+++ b/tests/unit/patchouli/kernel/test_runtime_alias_resolver.py
@@ -14,6 +14,7 @@ from hivememory.core.models import (
     PayloadLayer,
 )
 from hivememory.core.mtp.exceptions import BusRouteUnavailableError, StorageReadError
+from hivememory.engines.generation.models import PendingAtomSettlement
 
 from tests.unit.patchouli.mtp.conftest import make_mock_bus
 
@@ -60,6 +61,98 @@ async def test_resolve_l0_pending_hit(resolver_parts):
 
     assert result.kind == "pending"
     assert result.pending is pending
+    bus._mock_storage.get_memory_by_alias.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_settled_pending_redirect_l1_hit(resolver_parts):
+    resolver, pending_cache, atom_cache, bus = resolver_parts
+    pending = pending_cache.register_write(
+        content="pending content",
+        title="Pending Note",
+        reason=None,
+        identity=Identity(user_id="test_user"),
+    )
+    canonical = _make_memory(alias="fact_canonical", content="canonical content")
+    atom_cache.ingest_atom(canonical)
+    settlement = PendingAtomSettlement(
+        pending_alias=pending.pending_alias,
+        intent_id=pending.intent_id,
+        status="COMMITTED",
+        duplicate_decision="CREATE",
+        canonical_alias="fact_canonical",
+        canonical_uuid=str(canonical.id),
+    )
+
+    pending_cache.apply_settlement(settlement)
+    result = await resolver.resolve(pending.pending_alias)
+
+    assert result.kind == "redirect"
+    assert result.requested_alias == pending.pending_alias
+    assert result.pending is pending
+    assert result.settlement is settlement
+    assert result.canonical_alias == "fact_canonical"
+    assert result.canonical_uuid == str(canonical.id)
+    assert result.atom is canonical
+    assert pending_cache.get_redirect(pending.pending_alias) is settlement
+    assert pending.pending_alias in pending_cache.get_pending_aliases_for_canonical_uuid(
+        str(canonical.id)
+    )
+    bus._mock_storage.get_memory_by_alias.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_settled_pending_redirect_l2_hit(resolver_parts):
+    resolver, pending_cache, atom_cache, bus = resolver_parts
+    pending = pending_cache.register_write(
+        content="pending content",
+        title="Pending Note",
+        reason=None,
+        identity=Identity(user_id="test_user"),
+    )
+    canonical = _make_memory(alias="fact_canonical", content="from storage")
+    bus._mock_storage.get_memory_by_alias.return_value = canonical
+    settlement = PendingAtomSettlement(
+        pending_alias=pending.pending_alias,
+        intent_id=pending.intent_id,
+        status="MERGED",
+        duplicate_decision="UPDATE",
+        canonical_alias="fact_canonical",
+        canonical_uuid=str(canonical.id),
+    )
+
+    pending_cache.apply_settlement(settlement)
+    result = await resolver.resolve(pending.pending_alias)
+
+    assert result.kind == "redirect"
+    assert result.atom is canonical
+    assert atom_cache.get_atom_by_alias("fact_canonical") is canonical
+
+
+@pytest.mark.asyncio
+async def test_resolve_discarded_pending_without_redirect(resolver_parts):
+    resolver, pending_cache, _atom_cache, bus = resolver_parts
+    pending = pending_cache.register_write(
+        content="pending content",
+        title="Pending Note",
+        reason=None,
+        identity=Identity(user_id="test_user"),
+    )
+    settlement = PendingAtomSettlement(
+        pending_alias=pending.pending_alias,
+        intent_id=pending.intent_id,
+        status="DISCARDED",
+        duplicate_decision="DISCARD",
+        message="Not materialized.",
+    )
+
+    pending_cache.apply_settlement(settlement)
+    result = await resolver.resolve(pending.pending_alias)
+
+    assert result.kind == "discarded"
+    assert result.pending is pending
+    assert result.settlement is settlement
+    assert result.atom is None
     bus._mock_storage.get_memory_by_alias.assert_not_called()
 
 

--- a/tests/unit/patchouli/kernel/test_sub_agent_call.py
+++ b/tests/unit/patchouli/kernel/test_sub_agent_call.py
@@ -58,6 +58,7 @@ class TestExecutionFrame:
         assert not frame.is_sub_frame()
         assert not frame.is_transient()
         assert frame.harvested_aliases == []
+        assert frame.run_id == ""
 
     def test_create_sub_frame(self):
         """depth=1 的子帧（瞬态沙盒）"""
@@ -74,6 +75,7 @@ class TestExecutionFrame:
         assert frame.is_sub_frame()
         assert frame.is_transient()
         assert frame.parent_frame_id == "pid_main_1"
+        assert frame.run_id == ""
 
     def test_harvest_alias(self):
         """别名收割"""
@@ -245,6 +247,7 @@ class TestFrameScheduler:
         assert frame.depth == 0
         assert frame.topic_id == "t1"
         assert frame.is_main_frame()
+        assert frame.run_id.startswith("run_")
 
     def test_suspend_resume(self):
         """帧挂起/恢复"""
@@ -301,6 +304,7 @@ class TestFrameScheduler:
         assert sub_frame.depth == 1
         assert sub_frame.topic_id is None
         assert sub_frame.parent_frame_id == main_frame.process_id
+        assert sub_frame.run_id == main_frame.run_id
         assert sub_frame.is_sub_frame()
         assert sub_frame.is_transient()
         assert len(sub_frame.working_history) == 2  # system + user

--- a/tests/unit/patchouli/kernel/test_sub_agent_call.py
+++ b/tests/unit/patchouli/kernel/test_sub_agent_call.py
@@ -25,7 +25,7 @@ from hivememory.core.models import (
     MemoryType,
     OMNI_DOLL_PROFILE,
 )
-from hivememory.alice.runtime.models import ExecutionFrame
+from hivememory.alice.runtime.models import ExecutionFrame, RuntimeScope
 from hivememory.prompts.assembler import AgentPromptAssembler
 from hivememory.system.config import KoakumaConfig
 from hivememory.core.mtp import (
@@ -47,10 +47,9 @@ class TestExecutionFrame:
     def test_create_main_frame(self):
         """depth=0 的主帧"""
         frame = ExecutionFrame(
-            process_id="pid_main_1",
+            runtime_scope=RuntimeScope(frame_id="frame_main_1", depth=0),
             agent_profile=OMNI_DOLL_PROFILE,
             working_history=[{"role": "system", "content": "test"}],
-            depth=0,
             topic_id="topic_123",
             identity=Identity(user_id="u1"),
         )
@@ -58,32 +57,33 @@ class TestExecutionFrame:
         assert not frame.is_sub_frame()
         assert not frame.is_transient()
         assert frame.harvested_aliases == []
-        assert frame.run_id == ""
+        assert frame.runtime_scope.run_id == ""
 
     def test_create_sub_frame(self):
         """depth=1 的子帧（瞬态沙盒）"""
         frame = ExecutionFrame(
-            process_id="pid_sub_1",
+            runtime_scope=RuntimeScope(
+                frame_id="frame_sub_1",
+                parent_frame_id="frame_main_1",
+                depth=1,
+            ),
             agent_profile=OMNI_DOLL_PROFILE,
             working_history=[{"role": "user", "content": "write tests"}],
-            depth=1,
             topic_id=None,
-            parent_frame_id="pid_main_1",
             identity=Identity(user_id="u1"),
         )
         assert not frame.is_main_frame()
         assert frame.is_sub_frame()
         assert frame.is_transient()
-        assert frame.parent_frame_id == "pid_main_1"
-        assert frame.run_id == ""
+        assert frame.runtime_scope.parent_frame_id == "frame_main_1"
+        assert frame.runtime_scope.run_id == ""
 
     def test_harvest_alias(self):
         """别名收割"""
         frame = ExecutionFrame(
-            process_id="pid_sub_1",
+            runtime_scope=RuntimeScope(frame_id="frame_sub_1", depth=1),
             agent_profile=OMNI_DOLL_PROFILE,
             working_history=[],
-            depth=1,
             topic_id=None,
             identity=Identity(user_id="u1"),
         )
@@ -150,7 +150,7 @@ class TestKoakumaHandleCall:
         koakuma.context = MTPExecutionContext(
             identity=Identity(user_id="u1", agent_id="omni_doll"),
             agent_profile=OMNI_DOLL_PROFILE,
-            depth=depth,
+            runtime_scope=RuntimeScope(depth=depth),
         )
 
         # 绑定真实方法
@@ -244,10 +244,11 @@ class TestFrameScheduler:
             identity=Identity(user_id="u1"),
         )
 
-        assert frame.depth == 0
+        assert frame.runtime_scope.depth == 0
         assert frame.topic_id == "t1"
         assert frame.is_main_frame()
-        assert frame.run_id.startswith("run_")
+        assert frame.runtime_scope.run_id.startswith("run_")
+        assert frame.runtime_scope.frame_id.startswith("frame_main_")
 
     def test_suspend_resume(self):
         """帧挂起/恢复"""
@@ -301,10 +302,11 @@ class TestFrameScheduler:
             shared_context="",
         )
 
-        assert sub_frame.depth == 1
+        assert sub_frame.runtime_scope.depth == 1
         assert sub_frame.topic_id is None
-        assert sub_frame.parent_frame_id == main_frame.process_id
-        assert sub_frame.run_id == main_frame.run_id
+        assert sub_frame.runtime_scope.frame_id.startswith("frame_sub_")
+        assert sub_frame.runtime_scope.parent_frame_id == main_frame.runtime_scope.frame_id
+        assert sub_frame.runtime_scope.run_id == main_frame.runtime_scope.run_id
         assert sub_frame.is_sub_frame()
         assert sub_frame.is_transient()
         assert len(sub_frame.working_history) == 2  # system + user

--- a/tests/unit/patchouli/mtp/conftest.py
+++ b/tests/unit/patchouli/mtp/conftest.py
@@ -15,6 +15,8 @@ import pytest
 
 from hivememory.system.runtime.bus.async_bus import AsyncSystemBus
 from hivememory.system.contracts.routes import GlobalRoutes
+from hivememory.alice.runtime.cache import KoakumaAtomCache, PendingAtomCache
+from hivememory.alice.runtime.resolver import RuntimeAliasResolver
 
 
 class MockAsyncBus(AsyncSystemBus):
@@ -108,4 +110,23 @@ def make_mock_bus(
         mock_storage=mock_storage,
         mock_retrieval=mock_retrieval,
         mock_generation=mock_generation,
+    )
+
+
+def make_runtime_alias_resolver(bus: MockAsyncBus) -> RuntimeAliasResolver:
+    return RuntimeAliasResolver(
+        pending_cache=PendingAtomCache(),
+        atom_cache=KoakumaAtomCache(),
+        bus=bus,
+    )
+
+
+def make_koakuma_runtime(bus: MockAsyncBus, config=None):
+    from hivememory.alice.runtime.koakuma import KoakumaRuntime
+    from hivememory.system.config import KoakumaConfig
+
+    return KoakumaRuntime(
+        bus=bus,
+        config=config or KoakumaConfig(),
+        alias_resolver=make_runtime_alias_resolver(bus),
     )

--- a/tests/unit/patchouli/mtp/test_read_chain.py
+++ b/tests/unit/patchouli/mtp/test_read_chain.py
@@ -51,9 +51,9 @@ def _make_memory(
 
 @pytest.fixture
 def koakuma() -> KoakumaRuntime:
-    from .conftest import make_mock_bus
+    from .conftest import make_koakuma_runtime, make_mock_bus
     bus = make_mock_bus()
-    return KoakumaRuntime(bus=bus, config=KoakumaConfig())
+    return make_koakuma_runtime(bus, KoakumaConfig())
 
 
 def _execute_mtp(koakuma: KoakumaRuntime, text: str, context=None):
@@ -88,7 +88,7 @@ class TestReadAliasResolution:
 
     def test_all_valid(self, koakuma):
         mem = _make_memory(content="resolved content", alias="fact_a")
-        koakuma._atom_cache.ingest_atom(mem)
+        koakuma.atom_cache.ingest_atom(mem)
 
         result = _execute_mtp(koakuma, '⟪ READ | fact_a | ⟫')
 
@@ -109,7 +109,7 @@ class TestReadAliasResolution:
     def test_mixed_valid_invalid(self, koakuma):
         """混合有效/无效别名"""
         mem = _make_memory(content="valid content", alias="good_alias")
-        koakuma._atom_cache.ingest_atom(mem)
+        koakuma.atom_cache.ingest_atom(mem)
         koakuma._bus._mock_storage.get_memory_by_alias.return_value = None  # L2 miss for bad_alias
 
         result = _execute_mtp(koakuma, '⟪ READ | [good_alias, bad_alias] | ⟫')
@@ -123,8 +123,8 @@ class TestReadAliasResolution:
         mem1 = _make_memory(content="content A", alias="a1")
         mem2 = _make_memory(content="content B", alias="a2")
 
-        koakuma._atom_cache.ingest_atom(mem1)
-        koakuma._atom_cache.ingest_atom(mem2)
+        koakuma.atom_cache.ingest_atom(mem1)
+        koakuma.atom_cache.ingest_atom(mem2)
 
         result = _execute_mtp(koakuma, '⟪ READ | [a1, a2] | ⟫')
 
@@ -138,7 +138,7 @@ class TestReadAliasResolution:
 
     def test_citation_failure_keeps_success_response(self, koakuma):
         mem = _make_memory(content="readable", alias="fact_cite_fail")
-        koakuma._atom_cache.ingest_atom(mem)
+        koakuma.atom_cache.ingest_atom(mem)
         koakuma._bus.unregister("patchouli.public.record_memory_citation")
 
         result = _execute_mtp(koakuma, '⟪ READ | fact_cite_fail | ⟫')
@@ -154,7 +154,7 @@ class TestKoakumaReadE2E:
 
     def test_read_single_alias(self, koakuma):
         mem = _make_memory(content="API documentation", alias="fact_api")
-        koakuma._atom_cache.ingest_atom(mem)
+        koakuma.atom_cache.ingest_atom(mem)
 
         result = _execute_mtp(koakuma, '⟪ READ | fact_api | ⟫')
 
@@ -164,8 +164,8 @@ class TestKoakumaReadE2E:
     def test_read_list_aliases(self, koakuma):
         mem1 = _make_memory(content="Doc A", alias="a1")
         mem2 = _make_memory(content="Doc B", alias="a2")
-        koakuma._atom_cache.ingest_atom(mem1)
-        koakuma._atom_cache.ingest_atom(mem2)
+        koakuma.atom_cache.ingest_atom(mem1)
+        koakuma.atom_cache.ingest_atom(mem2)
 
         result = _execute_mtp(koakuma, '⟪ READ | [a1, a2] | ⟫')
 
@@ -182,7 +182,7 @@ class TestKoakumaReadE2E:
 
     def test_read_formatted_response_xml(self, koakuma):
         mem = _make_memory(content="test", alias="test_alias")
-        koakuma._atom_cache.ingest_atom(mem)
+        koakuma.atom_cache.ingest_atom(mem)
 
         result = _execute_mtp(koakuma, '⟪ READ | test_alias | ⟫')
 
@@ -191,7 +191,7 @@ class TestKoakumaReadE2E:
 
     def test_read_via_intercept(self, koakuma):
         mem = _make_memory(content="intercepted content", alias="fact_x")
-        koakuma._atom_cache.ingest_atom(mem)
+        koakuma.atom_cache.ingest_atom(mem)
 
         agent_text = 'Let me read that. ⟪ READ | fact_x |'
         result = _intercept_and_execute(koakuma, agent_text)
@@ -203,7 +203,7 @@ class TestKoakumaReadE2E:
     def test_read_cache_hit_no_db_query(self, koakuma):
         """缓存命中后不查数据库"""
         mem = _make_memory(content="cached content", alias="fact_cached")
-        koakuma._atom_cache.ingest_atom(mem)
+        koakuma.atom_cache.ingest_atom(mem)
 
         result = _execute_mtp(koakuma, '⟪ READ | fact_cached | ⟫')
 
@@ -297,7 +297,7 @@ class TestReadL2Fallback:
         mem_l2 = _make_memory(content="from L2", alias="alias_l2")
 
         # 缓存注册
-        koakuma._atom_cache.ingest_atom(mem_cached)
+        koakuma.atom_cache.ingest_atom(mem_cached)
 
         # L2 返回
         koakuma._bus._mock_storage.get_memory_by_alias.return_value = mem_l2

--- a/tests/unit/patchouli/mtp/test_read_chain.py
+++ b/tests/unit/patchouli/mtp/test_read_chain.py
@@ -24,6 +24,7 @@ from hivememory.core.models import (
 )
 from hivememory.alice.runtime.koakuma import KoakumaRuntime
 from hivememory.alice.runtime.models import MTPExecutionContext
+from hivememory.engines.generation.models import PendingAtomSettlement
 from hivememory.system.config import KoakumaConfig
 
 
@@ -145,6 +146,66 @@ class TestReadAliasResolution:
 
         assert result.success
         assert "readable" in result.response_content
+
+    def test_read_redirected_pending_alias(self, koakuma):
+        pending = koakuma.pending_cache.register_write(
+            content="pending content",
+            title="Pending Note",
+            reason=None,
+            identity=MTPExecutionContext().identity,
+        )
+        canonical = _make_memory(
+            content="canonical content",
+            alias="fact_canonical",
+        )
+        koakuma.atom_cache.ingest_atom(canonical)
+        koakuma.pending_cache.apply_settlement(
+            PendingAtomSettlement(
+                pending_alias=pending.pending_alias,
+                intent_id=pending.intent_id,
+                status="COMMITTED",
+                duplicate_decision="CREATE",
+                canonical_alias="fact_canonical",
+                canonical_uuid=str(canonical.id),
+            )
+        )
+
+        result = _execute_mtp(koakuma, f'⟪ READ | {pending.pending_alias} | ⟫')
+
+        assert result.success
+        assert "[Alias Redirected]" in result.response_content
+        assert f"Requested alias: {pending.pending_alias}" in result.response_content
+        assert "Canonical alias: fact_canonical" in result.response_content
+        assert "[fact_canonical]:" in result.response_content
+        assert "canonical content" in result.response_content
+        assert "Use 'fact_canonical'" in result.response_content
+        assert koakuma._bus._memory_citations == [
+            {"memory_id": canonical.id, "source": "mtp.read"}
+        ]
+
+    def test_read_discarded_pending_alias(self, koakuma):
+        pending = koakuma.pending_cache.register_write(
+            content="pending content",
+            title="Pending Note",
+            reason=None,
+            identity=MTPExecutionContext().identity,
+        )
+        koakuma.pending_cache.apply_settlement(
+            PendingAtomSettlement(
+                pending_alias=pending.pending_alias,
+                intent_id=pending.intent_id,
+                status="DISCARDED",
+                duplicate_decision="DISCARD",
+                message="Not materialized.",
+            )
+        )
+
+        result = _execute_mtp(koakuma, f'⟪ READ | {pending.pending_alias} | ⟫')
+
+        assert result.success
+        assert "status: discarded" in result.response_content
+        assert "materialized: false" in result.response_content
+        assert "Not materialized." in result.response_content
 
 
 # ========== Test 3: Koakuma READ E2E ==========

--- a/tests/unit/patchouli/mtp/test_run_chain.py
+++ b/tests/unit/patchouli/mtp/test_run_chain.py
@@ -26,6 +26,7 @@ from hivememory.core.models import (
 )
 from hivememory.alice.runtime.koakuma import KoakumaRuntime
 from hivememory.alice.runtime.models import MTPExecutionContext
+from hivememory.engines.generation.models import PendingAtomSettlement
 from hivememory.system.config import KoakumaConfig
 
 
@@ -291,6 +292,40 @@ class TestRunUserToolPath:
         # 验证没有查 Qdrant
         koakuma._bus._mock_storage.get_memory.assert_not_called()
         koakuma._bus._mock_storage.get_memory_by_alias.assert_not_called()
+
+    def test_redirected_pending_alias_executes_canonical_tool(self, koakuma):
+        pending = koakuma.pending_cache.register_write(
+            content="pending tool",
+            title="Pending Tool",
+            reason=None,
+            identity=MTPExecutionContext().identity,
+        )
+        canonical = _make_code_memory(
+            code="print('redirected tool output')",
+            alias="tool_canonical",
+        )
+        koakuma.atom_cache.ingest_atom(canonical)
+        koakuma.pending_cache.apply_settlement(
+            PendingAtomSettlement(
+                pending_alias=pending.pending_alias,
+                intent_id=pending.intent_id,
+                status="COMMITTED",
+                duplicate_decision="CREATE",
+                canonical_alias="tool_canonical",
+                canonical_uuid=str(canonical.id),
+            )
+        )
+
+        result = _execute_mtp(koakuma, f'⟪ RUN | {pending.pending_alias} | ⟫')
+
+        assert result.success
+        assert "[Alias Redirected]" in result.response_content
+        assert f"Requested alias: {pending.pending_alias}" in result.response_content
+        assert "Canonical alias: tool_canonical" in result.response_content
+        assert "redirected tool output" in result.response_content
+        assert koakuma._bus._memory_citations == [
+            {"memory_id": canonical.id, "source": "mtp.run"}
+        ]
 
     def test_user_tool_success_returns_execution_result(self, koakuma):
         """成功执行后返回工具输出，trace 由 TurnEvent reducer 负责生成。"""

--- a/tests/unit/patchouli/mtp/test_run_chain.py
+++ b/tests/unit/patchouli/mtp/test_run_chain.py
@@ -71,9 +71,9 @@ def _make_fact_memory(mem_id=None, alias: str = "fact_not_tool") -> MemoryAtom:
 
 @pytest.fixture
 def koakuma() -> KoakumaRuntime:
-    from .conftest import make_mock_bus
+    from .conftest import make_koakuma_runtime, make_mock_bus
     bus = make_mock_bus()
-    return KoakumaRuntime(bus=bus, config=KoakumaConfig())
+    return make_koakuma_runtime(bus, KoakumaConfig())
 
 
 def _execute_mtp(koakuma: KoakumaRuntime, text: str, context=None):
@@ -190,7 +190,7 @@ class TestRunUserToolPath:
     def test_l1_alias_hit_executes(self, koakuma):
         """L1 别名命中 → 加载 → 执行"""
         mem = _make_code_memory(code="print('from l1')", alias="tool_l1")
-        koakuma._atom_cache.ingest_atom(mem)
+        koakuma.atom_cache.ingest_atom(mem)
 
         result = _execute_mtp(koakuma, '⟪ RUN | tool_l1 | ⟫')
 
@@ -226,7 +226,7 @@ class TestRunUserToolPath:
     def test_non_code_snippet_rejected(self, koakuma):
         """类型不是 CODE_SNIPPET 时拒绝执行"""
         fact_mem = _make_fact_memory()
-        koakuma._atom_cache.ingest_atom(fact_mem)
+        koakuma.atom_cache.ingest_atom(fact_mem)
 
         result = _execute_mtp(koakuma, '⟪ RUN | fact_not_tool | ⟫')
 
@@ -282,7 +282,7 @@ class TestRunUserToolPath:
     def test_cache_hit_after_ingest(self, koakuma):
         """缓存命中后直接执行，不查 Qdrant"""
         mem = _make_code_memory(code="print('cached')", alias="tool_cached_ingest")
-        koakuma._atom_cache.ingest_atom(mem)
+        koakuma.atom_cache.ingest_atom(mem)
 
         result = _execute_mtp(koakuma, '⟪ RUN | tool_cached_ingest | ⟫')
 
@@ -317,11 +317,10 @@ class TestRunUserToolPath:
 
     def test_citation_failure_keeps_user_tool_success_response(self, koakuma):
         mem = _make_code_memory(code="print('still ok')", alias="tool_cite_fail")
-        koakuma._atom_cache.ingest_atom(mem)
+        koakuma.atom_cache.ingest_atom(mem)
         koakuma._bus.unregister("patchouli.public.record_memory_citation")
 
         result = _execute_mtp(koakuma, '⟪ RUN | tool_cite_fail | ⟫')
 
         assert result.success
         assert "still ok" in result.response_content
-

--- a/tests/unit/patchouli/mtp/test_search_chain.py
+++ b/tests/unit/patchouli/mtp/test_search_chain.py
@@ -67,11 +67,11 @@ def _make_retrieval_response(memories=None, rendered_context=None) -> RetrievalR
 
 @pytest.fixture
 def koakuma() -> KoakumaRuntime:
-    from .conftest import make_mock_bus
+    from .conftest import make_koakuma_runtime, make_mock_bus
     mock_retrieval = MagicMock()
     mock_retrieval.retrieve.return_value = _make_retrieval_response()
     bus = make_mock_bus(mock_retrieval=mock_retrieval)
-    return KoakumaRuntime(bus=bus, config=KoakumaConfig())
+    return make_koakuma_runtime(bus, KoakumaConfig())
 
 
 def _execute_mtp(koakuma: KoakumaRuntime, text: str, context=None):
@@ -304,8 +304,8 @@ class TestSearchAliasRegistration:
 
         _execute_mtp(koakuma, '⟪ SEARCH | * | query="api spec" ⟫')
 
-        assert koakuma._atom_cache.has_alias("fact_api_spec")
-        atom = koakuma._atom_cache.get_atom_by_alias("fact_api_spec")
+        assert koakuma.atom_cache.has_alias("fact_api_spec")
+        atom = koakuma.atom_cache.get_atom_by_alias("fact_api_spec")
         assert atom is not None
         assert str(atom.id) == str(mem.id)
 
@@ -318,8 +318,8 @@ class TestSearchAliasRegistration:
 
         _execute_mtp(koakuma, '⟪ SEARCH | * | query="test" ⟫')
 
-        assert koakuma._atom_cache.has_alias("fact_a")
-        assert koakuma._atom_cache.has_alias("fact_b")
+        assert koakuma.atom_cache.has_alias("fact_a")
+        assert koakuma.atom_cache.has_alias("fact_b")
 
     def test_registered_alias_resolvable_by_read(self, koakuma):
         """SEARCH 注册的 alias 可被 READ 解析"""

--- a/tests/unit/patchouli/mtp/test_update_chain.py
+++ b/tests/unit/patchouli/mtp/test_update_chain.py
@@ -115,29 +115,28 @@ class TestUpdateFocusModel:
         focus = UpdateFocus(
             instruction="把端口改成 9090",
             content="port = 9090",
-            target_uuid="uuid-123",
-            target_alias="fact_api_port",
+            base_uuid="uuid-123",
+            base_alias="fact_api_port",
         )
         assert focus.instruction == "把端口改成 9090"
         assert focus.content == "port = 9090"
-        assert focus.target_uuid == "uuid-123"
-        assert focus.target_alias == "fact_api_port"
+        assert focus.base_uuid == "uuid-123"
+        assert focus.base_alias == "fact_api_port"
 
     def test_defaults(self):
         focus = UpdateFocus(
             instruction="修改端口",
-            target_uuid="uuid-123",
-            target_alias="fact_api_port",
+            base_uuid="uuid-123",
+            base_alias="fact_api_port",
         )
         assert focus.content is None
-        assert focus.existing_memory is None
         assert focus.identity is not None
 
     def test_with_identity(self, identity):
         focus = UpdateFocus(
             instruction="test",
-            target_uuid="uuid-123",
-            target_alias="alias",
+            base_uuid="uuid-123",
+            base_alias="alias",
             identity=identity,
         )
         assert focus.identity.user_id == "test_user"
@@ -145,20 +144,20 @@ class TestUpdateFocusModel:
 
     def test_instruction_required(self):
         with pytest.raises(Exception):
-            UpdateFocus(target_uuid="uuid-123", target_alias="alias")
+            UpdateFocus(base_uuid="uuid-123", base_alias="alias")
 
-    def test_target_uuid_required(self):
+    def test_base_uuid_required(self):
         with pytest.raises(Exception):
-            UpdateFocus(instruction="test", target_alias="alias")
+            UpdateFocus(instruction="test", base_alias="alias")
 
-    def test_existing_memory_injection(self, existing_memory):
+    def test_generation_request_existing_memory(self, existing_memory):
         focus = UpdateFocus(
             instruction="test",
-            target_uuid="uuid-123",
-            target_alias="alias",
+            base_uuid="uuid-123",
+            base_alias="alias",
         )
-        focus.existing_memory = existing_memory
-        assert focus.existing_memory.index.title == "API 端口配置"
+        req = GenerationRequest(update_focus=focus, existing_memory=existing_memory)
+        assert req.existing_memory.index.title == "API 端口配置"
 
 
 # ========== Test 2: MergeResult Model ==========
@@ -191,7 +190,7 @@ class TestGenerationRequestUpdate:
 
     def test_is_update_with_update_focus(self):
         uf = UpdateFocus(
-            instruction="test", target_uuid="uuid-123", target_alias="alias",
+            instruction="test", base_uuid="uuid-123", base_alias="alias",
         )
         req = GenerationRequest(update_focus=uf)
         assert req.is_update
@@ -210,7 +209,7 @@ class TestGenerationRequestUpdate:
 
     def test_update_with_context(self, sample_context):
         uf = UpdateFocus(
-            instruction="test", target_uuid="uuid-123", target_alias="alias",
+            instruction="test", base_uuid="uuid-123", base_alias="alias",
         )
         req = GenerationRequest(context=sample_context, update_focus=uf)
         assert req.is_update
@@ -237,13 +236,15 @@ class TestModeCMergePrompt:
 
         uf = UpdateFocus(
             instruction="把端口改成 9090",
-            target_uuid=str(existing_memory.id),
-            target_alias="fact_api_port",
+            base_uuid=str(existing_memory.id),
+            base_alias="fact_api_port",
             identity=identity,
         )
-        uf.existing_memory = existing_memory
-
-        request = GenerationRequest(context=sample_context, update_focus=uf)
+        request = GenerationRequest(
+            context=sample_context,
+            update_focus=uf,
+            existing_memory=existing_memory,
+        )
         result = engine.process(request=request)
 
         # merge() 被调用，extract() 不被调用
@@ -269,16 +270,15 @@ class TestModeCMergePrompt:
         )
 
         uf = UpdateFocus(
-            instruction="更新", target_uuid=str(existing_memory.id),
-            target_alias="fact_api_port", identity=identity,
+            instruction="更新", base_uuid=str(existing_memory.id),
+            base_alias="fact_api_port", identity=identity,
         )
-        uf.existing_memory = existing_memory
-
-        request = GenerationRequest(update_focus=uf)
+        request = GenerationRequest(update_focus=uf, existing_memory=existing_memory)
         result = engine.process(request=request)
 
         assert len(result) == 1
-        assert result[0].payload.content == "新内容"
+        assert result[0].atom.payload.content == "新内容"
+        assert result[0].operation == "updated"
         mock_storage.upsert_memory.assert_called_once()
 
 
@@ -299,21 +299,19 @@ class TestModeCFallback:
         uf = UpdateFocus(
             instruction="追加新内容",
             content="新增的段落",
-            target_uuid=str(existing_memory.id),
-            target_alias="fact_api_port",
+            base_uuid=str(existing_memory.id),
+            base_alias="fact_api_port",
             identity=identity,
         )
-        uf.existing_memory = existing_memory
-
-        request = GenerationRequest(update_focus=uf)
+        request = GenerationRequest(update_focus=uf, existing_memory=existing_memory)
         result = engine.process(request=request)
 
         # fallback 应该保底入库
         assert len(result) == 1
         assert mock_storage.upsert_memory.called
         # fallback 拼接: 旧内容 + 新内容
-        assert "新增的段落" in result[0].payload.content
-        assert existing_memory.payload.content.split("\n")[0] in result[0].payload.content
+        assert "新增的段落" in result[0].atom.payload.content
+        assert existing_memory.payload.content.split("\n")[0] in result[0].atom.payload.content
 
     def test_fallback_content_append(self, existing_memory):
         engine = MemoryGenerationEngine(
@@ -322,8 +320,8 @@ class TestModeCFallback:
         uf = UpdateFocus(
             instruction="追加内容",
             content="新段落文本",
-            target_uuid="uuid-123",
-            target_alias="alias",
+            base_uuid="uuid-123",
+            base_alias="alias",
         )
         result = engine._build_update_fallback(uf, existing_memory)
 
@@ -339,8 +337,8 @@ class TestModeCFallback:
         uf = UpdateFocus(
             instruction="删除过时信息",
             content=None,
-            target_uuid="uuid-123",
-            target_alias="alias",
+            base_uuid="uuid-123",
+            base_alias="alias",
         )
         result = engine._build_update_fallback(uf, existing_memory)
 
@@ -360,8 +358,8 @@ class TestModeCFallback:
 
         uf = UpdateFocus(
             instruction="test",
-            target_uuid="uuid-123",
-            target_alias="alias",
+            base_uuid="uuid-123",
+            base_alias="alias",
             identity=identity,
         )
         # 不注入 existing_memory (默认 None)
@@ -388,7 +386,7 @@ class TestApplyUpdate:
         result = engine._apply_update(existing_memory, merge_result)
 
         assert len(result) == 1
-        assert result[0].meta.version == old_version + 1
+        assert result[0].atom.meta.version == old_version + 1
 
     def test_content_updated(self, existing_memory, merge_result):
         engine = MemoryGenerationEngine(
@@ -396,7 +394,7 @@ class TestApplyUpdate:
         )
         result = engine._apply_update(existing_memory, merge_result)
 
-        assert result[0].payload.content == merge_result.new_content
+        assert result[0].atom.payload.content == merge_result.new_content
 
     def test_full_history_pushed(self, existing_memory, merge_result):
         engine = MemoryGenerationEngine(
@@ -406,7 +404,7 @@ class TestApplyUpdate:
 
         result = engine._apply_update(existing_memory, merge_result)
 
-        history = result[0].payload.artifacts.full_history
+        history = result[0].atom.payload.artifacts.full_history
         assert len(history) == 1
         assert history[0]["content"] == old_content
         assert history[0]["reason"] == merge_result.changelog
@@ -418,7 +416,7 @@ class TestApplyUpdate:
         )
         result = engine._apply_update(existing_memory, merge_result)
 
-        summary = result[0].payload.history_summary
+        summary = result[0].atom.payload.history_summary
         assert len(summary) == 1
         assert merge_result.changelog in summary[0]
 
@@ -429,7 +427,7 @@ class TestApplyUpdate:
         )
         result = engine._apply_update(existing_memory, merge_result)
 
-        assert result[0].meta.confidence_score == 1.0
+        assert result[0].atom.meta.confidence_score == 1.0
 
     def test_updated_at_set(self, existing_memory, merge_result):
         engine = MemoryGenerationEngine(
@@ -438,7 +436,25 @@ class TestApplyUpdate:
         before = datetime.now()
         result = engine._apply_update(existing_memory, merge_result)
 
-        assert result[0].meta.updated_at >= before
+        assert result[0].atom.meta.updated_at >= before
+
+    def test_pending_update_settlement_status_is_updated(self, existing_memory, merge_result):
+        engine = MemoryGenerationEngine(
+            storage=MagicMock(), extractor=MagicMock(), deduplicator=MagicMock(),
+        )
+
+        result = engine._apply_update(
+            existing_memory,
+            merge_result,
+            intent_id="intent_update_1",
+            pending_alias="rev_fact_api_port_1234",
+        )
+
+        assert result[0].operation == "updated"
+        assert result[0].settlement is not None
+        assert result[0].settlement.status == "UPDATED"
+        assert result[0].settlement.duplicate_decision is None
+        assert result[0].settlement.canonical_alias == existing_memory.get_alias()
 
     def test_persisted_to_storage(self, existing_memory, merge_result):
         mock_storage = MagicMock()
@@ -509,8 +525,8 @@ class TestFlushCallbackModesUpdate:
 
         focus = UpdateFocus(
             instruction="把端口改成 9090",
-            target_uuid=str(existing_memory.id),
-            target_alias="fact_api_port",
+            base_uuid=str(existing_memory.id),
+            base_alias="fact_api_port",
             identity=Identity(user_id="test_user"),
         )
 
@@ -530,7 +546,7 @@ class TestFlushCallbackModesUpdate:
         assert request.update_focus.instruction == "把端口改成 9090"
         assert request.write_focus is None
         # existing_memory 应被注入
-        assert request.update_focus.existing_memory is existing_memory
+        assert request.existing_memory is existing_memory
 
     @pytest.mark.asyncio
     async def test_mtp_write_flush_also_triggers(self, sample_messages):
@@ -638,7 +654,7 @@ class TestKoakumaUpdateE2E:
         assert focus is not None
         assert isinstance(focus, UpdateFocus)
         assert focus.instruction == "把端口改成 9090"
-        assert focus.target_alias == "fact_api_port"
+        assert focus.base_alias == "fact_api_port"
 
     def test_update_with_content(self, update_koakuma):
         agent_text = '⟪ UPDATE | fact_api_port | instruction="替换端口" content="port = 9090"'

--- a/tests/unit/patchouli/mtp/test_update_chain.py
+++ b/tests/unit/patchouli/mtp/test_update_chain.py
@@ -736,10 +736,14 @@ class TestKoakumaUpdateValidation:
         from .conftest import make_koakuma_runtime, make_mock_bus
         bus = make_mock_bus()
         koakuma = make_koakuma_runtime(bus, KoakumaConfig())
+        from hivememory.alice.runtime.models import RuntimeScope
+
         context = MTPExecutionContext(
             identity=Identity(user_id="test_user"),
-            run_id="run_update_test",
-            frame_id="pid_main_update",
+            runtime_scope=RuntimeScope(
+                run_id="run_update_test",
+                frame_id="frame_main_update",
+            ),
         )
         koakuma.atom_cache.ingest_atom(existing_memory)
 
@@ -752,8 +756,8 @@ class TestKoakumaUpdateValidation:
         assert result.update_focus.instruction == "test"
         pending = koakuma.pending_cache.get(result.pending_alias)
         assert pending is not None
-        assert pending.run_id == "run_update_test"
-        assert pending.frame_id == "pid_main_update"
+        assert pending.runtime_scope.run_id == "run_update_test"
+        assert pending.runtime_scope.frame_id == "frame_main_update"
 
 
 # ========== Test 11: FlushReason.MTP_UPDATE ==========

--- a/tests/unit/patchouli/mtp/test_update_chain.py
+++ b/tests/unit/patchouli/mtp/test_update_chain.py
@@ -617,9 +617,9 @@ class TestKoakumaUpdateE2E:
         mock_librarian = MagicMock()
         mock_librarian.handle_update_signal.return_value = [existing_memory]
 
-        from .conftest import make_mock_bus
+        from .conftest import make_koakuma_runtime, make_mock_bus
         bus = make_mock_bus()
-        koakuma = KoakumaRuntime(bus=bus, config=KoakumaConfig())
+        koakuma = make_koakuma_runtime(bus, KoakumaConfig())
         koakuma.context = MTPExecutionContext(identity=Identity(user_id="test_user"))
 
         # 注册 alias 到缓存
@@ -667,9 +667,9 @@ class TestKoakumaUpdateValidation:
 
     @pytest.fixture
     def validation_koakuma(self) -> KoakumaRuntime:
-        from .conftest import make_mock_bus
+        from .conftest import make_koakuma_runtime, make_mock_bus
         bus = make_mock_bus()
-        koakuma = KoakumaRuntime(bus=bus, config=KoakumaConfig())
+        koakuma = make_koakuma_runtime(bus, KoakumaConfig())
         koakuma.context = MTPExecutionContext(identity=Identity(user_id="test_user"))
         return koakuma
 
@@ -703,6 +703,22 @@ class TestKoakumaUpdateValidation:
         assert "not found" in result.formatted_response.lower() or "error" in result.formatted_response.lower()
         assert result.update_focus is None
 
+    def test_pending_alias_rejected(self, validation_koakuma):
+        pending = validation_koakuma.pending_cache.register_write(
+            content="pending content",
+            title="Pending Note",
+            reason=None,
+            identity=validation_koakuma.context.identity,
+        )
+
+        agent_text = f'⟪ UPDATE | {pending.pending_alias} | instruction="test"'
+        result = _intercept_and_execute(validation_koakuma, agent_text, context=validation_koakuma.context)
+
+        assert result is not None
+        assert not result.success
+        assert "Pending Alias Not Updatable" in result.response_content
+        assert result.update_focus is None
+
     def test_l2_route_failure_returns_infra_error(self, validation_koakuma):
         validation_koakuma._bus._mock_storage.get_memory_by_alias.side_effect = KeyError(
             "AsyncSystemBus: route 'memory.retrieve_by_aliases' not registered"
@@ -717,9 +733,9 @@ class TestKoakumaUpdateValidation:
 
     def test_update_deferred_capture_always_ack(self, existing_memory):
         """v3.0 延迟捕获: UPDATE 在 Koakuma 层始终返回 ACK"""
-        from .conftest import make_mock_bus
+        from .conftest import make_koakuma_runtime, make_mock_bus
         bus = make_mock_bus()
-        koakuma = KoakumaRuntime(bus=bus, config=KoakumaConfig())
+        koakuma = make_koakuma_runtime(bus, KoakumaConfig())
         context = MTPExecutionContext(identity=Identity(user_id="test_user"))
         koakuma.atom_cache.ingest_atom(existing_memory)
 

--- a/tests/unit/patchouli/mtp/test_update_chain.py
+++ b/tests/unit/patchouli/mtp/test_update_chain.py
@@ -736,7 +736,11 @@ class TestKoakumaUpdateValidation:
         from .conftest import make_koakuma_runtime, make_mock_bus
         bus = make_mock_bus()
         koakuma = make_koakuma_runtime(bus, KoakumaConfig())
-        context = MTPExecutionContext(identity=Identity(user_id="test_user"))
+        context = MTPExecutionContext(
+            identity=Identity(user_id="test_user"),
+            run_id="run_update_test",
+            frame_id="pid_main_update",
+        )
         koakuma.atom_cache.ingest_atom(existing_memory)
 
         agent_text = '⟪ UPDATE | fact_api_port | instruction="test"'
@@ -746,6 +750,10 @@ class TestKoakumaUpdateValidation:
         assert result.success
         assert result.update_focus is not None
         assert result.update_focus.instruction == "test"
+        pending = koakuma.pending_cache.get(result.pending_alias)
+        assert pending is not None
+        assert pending.run_id == "run_update_test"
+        assert pending.frame_id == "pid_main_update"
 
 
 # ========== Test 11: FlushReason.MTP_UPDATE ==========

--- a/tests/unit/patchouli/mtp/test_write_chain.py
+++ b/tests/unit/patchouli/mtp/test_write_chain.py
@@ -493,10 +493,14 @@ class TestKoakumaWriteE2E:
         from .conftest import make_koakuma_runtime, make_mock_bus
         bus = make_mock_bus()
         koakuma = make_koakuma_runtime(bus, KoakumaConfig())
+        from hivememory.alice.runtime.models import RuntimeScope
+
         context = MTPExecutionContext(
             identity=Identity(user_id="test_user"),
-            run_id="run_write_test",
-            frame_id="pid_main_write",
+            runtime_scope=RuntimeScope(
+                run_id="run_write_test",
+                frame_id="frame_main_write",
+            ),
         )
 
         agent_text = '⟪ WRITE | * | content="test"'
@@ -508,8 +512,8 @@ class TestKoakumaWriteE2E:
         assert result.write_focus.content == "test"
         pending = koakuma.pending_cache.get(result.pending_alias)
         assert pending is not None
-        assert pending.run_id == "run_write_test"
-        assert pending.frame_id == "pid_main_write"
+        assert pending.runtime_scope.run_id == "run_write_test"
+        assert pending.runtime_scope.frame_id == "frame_main_write"
 
 
 # ========== Test 8: FlushReason.MTP_WRITE ==========

--- a/tests/unit/patchouli/mtp/test_write_chain.py
+++ b/tests/unit/patchouli/mtp/test_write_chain.py
@@ -443,9 +443,9 @@ class TestKoakumaWriteE2E:
         mock_librarian = MagicMock()
         mock_librarian.handle_write_signal.return_value = [sample_memory]
 
-        from .conftest import make_mock_bus
+        from .conftest import make_koakuma_runtime, make_mock_bus
         bus = make_mock_bus()
-        koakuma = KoakumaRuntime(bus=bus, config=KoakumaConfig())
+        koakuma = make_koakuma_runtime(bus, KoakumaConfig())
         koakuma.context = MTPExecutionContext(identity=Identity(user_id="test_user"))
         return koakuma
 
@@ -490,9 +490,9 @@ class TestKoakumaWriteE2E:
 
     def test_write_deferred_capture_always_ack(self):
         """v3.0 延迟捕获: WRITE 在 Koakuma 层始终返回 ACK，实际执行延迟到 payload 提交"""
-        from .conftest import make_mock_bus
+        from .conftest import make_koakuma_runtime, make_mock_bus
         bus = make_mock_bus()
-        koakuma = KoakumaRuntime(bus=bus, config=KoakumaConfig())
+        koakuma = make_koakuma_runtime(bus, KoakumaConfig())
         context = MTPExecutionContext(identity=Identity(user_id="test_user"))
 
         agent_text = '⟪ WRITE | * | content="test"'

--- a/tests/unit/patchouli/mtp/test_write_chain.py
+++ b/tests/unit/patchouli/mtp/test_write_chain.py
@@ -493,7 +493,11 @@ class TestKoakumaWriteE2E:
         from .conftest import make_koakuma_runtime, make_mock_bus
         bus = make_mock_bus()
         koakuma = make_koakuma_runtime(bus, KoakumaConfig())
-        context = MTPExecutionContext(identity=Identity(user_id="test_user"))
+        context = MTPExecutionContext(
+            identity=Identity(user_id="test_user"),
+            run_id="run_write_test",
+            frame_id="pid_main_write",
+        )
 
         agent_text = '⟪ WRITE | * | content="test"'
         result = _intercept_and_execute(koakuma, agent_text, context=context)
@@ -502,6 +506,10 @@ class TestKoakumaWriteE2E:
         assert result.success
         assert result.write_focus is not None
         assert result.write_focus.content == "test"
+        pending = koakuma.pending_cache.get(result.pending_alias)
+        assert pending is not None
+        assert pending.run_id == "run_write_test"
+        assert pending.frame_id == "pid_main_write"
 
 
 # ========== Test 8: FlushReason.MTP_WRITE ==========

--- a/tests/unit/system/test_ingest_passive.py
+++ b/tests/unit/system/test_ingest_passive.py
@@ -216,8 +216,8 @@ class TestMessageGazeResultPropagation:
         payload, _ = buf.flush()
 
         assert payload.mtp_traces == []
-        assert payload.write_focus is None
-        assert payload.update_focus is None
+        assert payload.write_focus == []
+        assert payload.update_focus == []
 
     def test_identity_preserved_in_payload(self):
         identity = _make_identity(user_id="u99", agent_id="bot", session_id="s1")

--- a/tests/unit/system/test_patchouli_alice_bus_integration.py
+++ b/tests/unit/system/test_patchouli_alice_bus_integration.py
@@ -161,8 +161,8 @@ async def test_finalize_agent_run_reads_focus_from_loop_result():
     payload = kernel.librarian_core.submit_interaction.await_args.args[0]
     assert payload.mtp_traces
     assert payload.mtp_traces[0].action == "SEARCH"
-    assert payload.write_focus is None
-    assert payload.update_focus is None
+    assert payload.write_focus == []
+    assert payload.update_focus == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/system/test_public_routes.py
+++ b/tests/unit/system/test_public_routes.py
@@ -1,10 +1,20 @@
 """公开路由注册/卸载测试 — 验证 System 门面在生命周期中正确管理全局总线路由。"""
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
 from hivememory.alice.contracts.public_routes import AliceRoutes
 from hivememory.alice.system import AliceSystem
+from hivememory.core.models import (
+    IndexLayer,
+    MemoryAtom,
+    MemoryType,
+    MetaData,
+    PayloadLayer,
+)
+from hivememory.engines.generation.models import PendingAtomSettlement
 from hivememory.patchouli.contracts.local_events import PatchouliLocalEvents
 from hivememory.patchouli.contracts.public_routes import PatchouliRoutes
 from hivememory.patchouli.system import PatchouliSystem
@@ -14,6 +24,21 @@ from hivememory.system.runtime.bus.global_bus import GlobalSystemBus
 
 
 # ========== Alice ==========
+
+
+def _make_memory(alias: str, content: str) -> MemoryAtom:
+    return MemoryAtom(
+        id=uuid4(),
+        meta=MetaData(user_id="test_user", source_agent_id="test_agent"),
+        index=IndexLayer(
+            title="Test Memory",
+            summary="A test memory for public route behavior",
+            tags=["test"],
+            memory_type=MemoryType.FACT,
+            alias=alias,
+        ),
+        payload=PayloadLayer(content=content),
+    )
 
 
 class TestAlicePublicRoutes:
@@ -149,6 +174,39 @@ class TestAlicePublicRoutes:
         await system.stop()
 
         assert GlobalEvents.PENDING_ATOM_SETTLED not in self.global_bus.list_events()
+
+    @pytest.mark.asyncio
+    async def test_settlement_refreshes_alice_l1_atom_cache(self):
+        stale_atom = _make_memory("fact_canonical", "stale content")
+        fresh_atom = _make_memory("fact_canonical", "fresh content")
+        retrieve_by_aliases = AsyncMock(
+            return_value=SimpleNamespace(memories=[fresh_atom])
+        )
+        self.global_bus.register(
+            GlobalRoutes.PATCHOULI_MEMORY_RETRIEVE_BY_ALIASES,
+            retrieve_by_aliases,
+        )
+        system = AliceSystem(config=self.config, global_bus=self.global_bus)
+        await system.start()
+        system.runtime._atom_cache.ingest_atom(stale_atom)
+
+        settlement = PendingAtomSettlement(
+            pending_alias="draft_memory_1234",
+            intent_id="intent_1234",
+            status="COMMITTED",
+            duplicate_decision="CREATE",
+            canonical_alias="fact_canonical",
+            canonical_uuid=str(fresh_atom.id),
+        )
+
+        await self.global_bus.publish(
+            GlobalEvents.PENDING_ATOM_SETTLED,
+            settlement=settlement,
+        )
+
+        retrieve_by_aliases.assert_awaited_once_with(aliases=["fact_canonical"])
+        assert system.runtime._atom_cache.get_atom_by_alias("fact_canonical") is fresh_atom
+        assert system.runtime._atom_cache.get_atom_by_uuid(str(stale_atom.id)) is None
 
 
 # ========== Patchouli (lightweight — full integration tested in test_bootstrap) ==========

--- a/tests/unit/system/test_public_routes.py
+++ b/tests/unit/system/test_public_routes.py
@@ -5,8 +5,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 from hivememory.alice.contracts.public_routes import AliceRoutes
 from hivememory.alice.system import AliceSystem
+from hivememory.patchouli.contracts.local_events import PatchouliLocalEvents
 from hivememory.patchouli.contracts.public_routes import PatchouliRoutes
 from hivememory.patchouli.system import PatchouliSystem
+from hivememory.system.contracts.events import GlobalEvents
 from hivememory.system.contracts.routes import GlobalRoutes
 from hivememory.system.runtime.bus.global_bus import GlobalSystemBus
 
@@ -137,6 +139,17 @@ class TestAlicePublicRoutes:
         get_agent_profile.assert_awaited_once_with("coder_doll")
         record_citation.assert_awaited_once_with(memory_id="mid", source="mtp.read")
 
+    @pytest.mark.asyncio
+    async def test_alice_unmount_unsubscribes_settlement_event(self):
+        system = AliceSystem(config=self.config, global_bus=self.global_bus)
+        await system.start()
+
+        assert GlobalEvents.PENDING_ATOM_SETTLED in self.global_bus.list_events()
+
+        await system.stop()
+
+        assert GlobalEvents.PENDING_ATOM_SETTLED not in self.global_bus.list_events()
+
 
 # ========== Patchouli (lightweight — full integration tested in test_bootstrap) ==========
 
@@ -195,3 +208,46 @@ class TestPatchouliPublicRoutes:
         routes = self.global_bus.list_routes()
         assert PatchouliRoutes.FINALIZE_AGENT_RUN not in routes
         assert PatchouliRoutes.RECORD_MEMORY_CITATION not in routes
+
+    @pytest.mark.asyncio
+    async def test_patchouli_local_settlement_event_bridges_to_global_bus(self):
+        system = MagicMock()
+        system._global_bus = self.global_bus
+        system.runtime = MagicMock()
+        system.runtime.local_bus = GlobalSystemBus()
+        system._forward_pending_atom_settled = (
+            PatchouliSystem._forward_pending_atom_settled.__get__(
+                system, PatchouliSystem
+            )
+        )
+        system._register_local_event_bridges = (
+            PatchouliSystem._register_local_event_bridges.__get__(
+                system, PatchouliSystem
+            )
+        )
+        system._unregister_local_event_bridges = (
+            PatchouliSystem._unregister_local_event_bridges.__get__(
+                system, PatchouliSystem
+            )
+        )
+
+        subscriber = AsyncMock()
+        self.global_bus.subscribe(GlobalEvents.PENDING_ATOM_SETTLED, subscriber)
+        settlement = object()
+
+        system._register_local_event_bridges()
+        await system.runtime.local_bus.publish(
+            PatchouliLocalEvents.PENDING_ATOM_SETTLED,
+            settlement=settlement,
+        )
+
+        subscriber.assert_awaited_once_with(settlement=settlement)
+
+        subscriber.reset_mock()
+        system._unregister_local_event_bridges()
+        await system.runtime.local_bus.publish(
+            PatchouliLocalEvents.PENDING_ATOM_SETTLED,
+            settlement=settlement,
+        )
+
+        subscriber.assert_not_awaited()


### PR DESCRIPTION
## 描述

增加记忆原子草稿态PendingAtom，解决 Agent 在同一 run 内发出 WRITE/UPDATE 后，由于记忆异步生成，导致无法立即读取刚提交的内容，也无法稳定拿到子 Agent 生成的 artifacts的问题

剩余临时句柄生命周期问题待后续解决

## 类型

- [ ] Bug 修复 (fix)
- [x] 新功能 (feat)
- [ ] 代码重构 (refactor)
- [ ] 文档更新 (docs)
- [ ] 代码风格更新 (style)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 构建/CI 更新 (build/ci)
- [ ] 其他变更 (chore)

## 相关 Issue

Resolve #36 

## 检查清单

- [x] 我已经阅读了项目的贡献指南
- [x] 我已经自我审查了代码，并确保其符合项目的代码风格与规范
- [x] 代码通过了 lint 检查
- [x] 添加了必要的测试用例并全部通过
- [x] 文档已更新（如有必要）

## 测试

添加并更新了已有测试

## 附加信息

无
