### PR TITLE
refactor:拆分MemoryGenerationTask至单独编排组件

### DIFF
--- a/src/hivememory/patchouli/services/__init__.py
+++ b/src/hivememory/patchouli/services/__init__.py
@@ -1,6 +1,7 @@
 """Patchouli internal microservices."""
 
 from hivememory.patchouli.services.librarian import LibrarianCore
+from hivememory.patchouli.services.memory_generation_tasks import MemoryGenerationTaskController
 from hivememory.patchouli.services.retrieval import RetrievalFamiliar
 
-__all__ = ["LibrarianCore", "RetrievalFamiliar"]
+__all__ = ["LibrarianCore", "MemoryGenerationTaskController", "RetrievalFamiliar"]

--- a/src/hivememory/patchouli/services/librarian.py
+++ b/src/hivememory/patchouli/services/librarian.py
@@ -16,37 +16,30 @@
 
 from __future__ import annotations
 
-import asyncio
-import logging
 import inspect
-import uuid
-from datetime import datetime, timezone
+import logging
 from time import monotonic
-from typing import List, Optional, TYPE_CHECKING, Dict, Any, Tuple
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple
 
 from hivememory.core.models import Identity
 from hivememory.core.models.pending import PendingAtomMaterializeTask
+from hivememory.core.protocol.models import InteractionPayload
+from hivememory.engines.generation.models import GenerationContext
 from hivememory.engines.perception.models import ArchivePayload
-from hivememory.engines.generation.models import (
-    GenerationRequest,
-    GenerationContext,
-    MemoryGenerationResult,
+from hivememory.infrastructure.storage import QdrantMemoryStore
+from hivememory.patchouli.services.memory_generation_tasks import (
+    MemoryGenerationTaskController,
 )
 from hivememory.prompts.transcript import GenerationTranscriptBuilder
-from hivememory.infrastructure.storage import QdrantMemoryStore
-from hivememory.patchouli.contracts.local_events import PatchouliLocalEvents
-from hivememory.core.protocol.models import InteractionPayload
 from hivememory.system.runtime.control import (
     MemoryGenerationTask,
     MemoryGenerationTaskRegistry,
-    MemoryGenerationTaskStatus,
-    MemoryGenerationSource,
 )
 
 if TYPE_CHECKING:
-    from hivememory.engines.perception.interfaces import BasePerceptionLayer
     from hivememory.engines.generation.engine import MemoryGenerationEngine
     from hivememory.engines.lifecycle.engine import MemoryLifecycleEngine
+    from hivememory.engines.perception.interfaces import BasePerceptionLayer
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +86,12 @@ class LibrarianCore:
         self.lifecycle_engine = lifecycle_engine
         self.perception_layer = perception_layer
         self.generation_engine = generation_engine
-        self._task_registry = task_registry or MemoryGenerationTaskRegistry()
+        self._memory_task_controller = MemoryGenerationTaskController(
+            storage=storage,
+            bus=bus,
+            generation_engine=generation_engine,
+            task_registry=task_registry,
+        )
 
         if self.perception_layer and hasattr(self.perception_layer, "set_generation_callback"):
             self.perception_layer.set_generation_callback(self._on_generate_memory)
@@ -135,168 +133,27 @@ class LibrarianCore:
             await self.perception_layer.route_and_ingest(target_topic_id, payload)
         else:
             logger.warning("perception_layer 未注入，跳过感知处理")
-    
-    async def _create_and_run_task(
-        self,
-        topic_id: str,
-        label: str,
-        source: MemoryGenerationSource,
-        coro_factory,
-        pending_alias: Optional[str] = None,
-        skip: bool = False,
-    ) -> MemoryGenerationTask:
-        """所有记忆生成链路的统一任务工厂 — 注册、调度、生命周期绑定。"""
-        memory_task = MemoryGenerationTask(
-            task_id=str(uuid.uuid4()),
-            topic_id=topic_id,
-            label=label,
-            source=source,
-            pending_alias=pending_alias,
-        )
-        self._task_registry.register(memory_task)
 
-        if skip or self.generation_engine is None:
-            self._task_registry.close(memory_task.task_id, MemoryGenerationTaskStatus.COMPLETED)
-            return memory_task
-
-        bg_task = asyncio.create_task(
-            coro_factory(memory_task),
-            name=f"memory_task_{memory_task.task_id[:8]}",
-        )
-        memory_task.attach_task(bg_task)
-
-        def _terminal_status() -> MemoryGenerationTaskStatus:
-            if memory_task.cancelled or memory_task.status == MemoryGenerationTaskStatus.CANCELLED:
-                return MemoryGenerationTaskStatus.CANCELLED
-            if memory_task.status == MemoryGenerationTaskStatus.FAILED:
-                return MemoryGenerationTaskStatus.FAILED
-            return MemoryGenerationTaskStatus.COMPLETED
-
-        def _mark_task_cancelled() -> None:
-            if memory_task.status not in (
-                MemoryGenerationTaskStatus.COMPLETED,
-                MemoryGenerationTaskStatus.FAILED,
-                MemoryGenerationTaskStatus.CANCELLED,
-            ):
-                memory_task.status = MemoryGenerationTaskStatus.CANCELLED
-
-        def _schedule_terminal_status_publish(status: MemoryGenerationTaskStatus) -> None:
-            if memory_task.finished_at is not None or self._bus is None:
-                return
-            memory_task.status = status
-            memory_task.finished_at = datetime.now(timezone.utc)
-            asyncio.create_task(
-                self._publish_memory_task_status(memory_task),
-                name=f"memory_task_status_{memory_task.task_id[:8]}",
-            )
-
-        def _done_callback(t: asyncio.Task) -> None:
-            if t.cancelled():
-                _mark_task_cancelled()
-                _schedule_terminal_status_publish(MemoryGenerationTaskStatus.CANCELLED)
-                self._task_registry.close(memory_task.task_id, MemoryGenerationTaskStatus.CANCELLED)
-                return
-
-            exc = t.exception()
-            if memory_task.cancelled:
-                _mark_task_cancelled()
-                _schedule_terminal_status_publish(MemoryGenerationTaskStatus.CANCELLED)
-                self._task_registry.close(memory_task.task_id, MemoryGenerationTaskStatus.CANCELLED)
-            elif exc is not None:
-                logger.error(f"memory task {memory_task.task_id} failed: {exc}", exc_info=exc)
-                _schedule_terminal_status_publish(MemoryGenerationTaskStatus.FAILED)
-                self._task_registry.close(memory_task.task_id, MemoryGenerationTaskStatus.FAILED)
-            else:
-                self._task_registry.close(memory_task.task_id, _terminal_status())
-
-        bg_task.add_done_callback(_done_callback)
-        return memory_task
-
-    async def _on_generate_memory(self, payload: "ArchivePayload") -> Optional[MemoryGenerationTask]:
-        """感知层 Archive 回调 — Mode A 被动记忆提取，接入任务观测与控制流。"""
+    async def _on_generate_memory(self, payload: ArchivePayload) -> Optional[MemoryGenerationTask]:
+        """感知层 Archive 回调 — Mode A 被动记忆提取。"""
         gen_context = self._build_generation_context(payload.blocks, payload.state_summary)
         if not gen_context.turns:
             logger.warning("空对话轮次，跳过处理")
             return None
 
-        return await self._create_and_run_task(
+        return await self._memory_task_controller.run_archive_generation(
             topic_id=payload.topic_id,
-            label=payload.topic_id,
-            source=MemoryGenerationSource.ARCHIVE,
-            coro_factory=lambda mt: self._run_archive_task(mt, gen_context),
+            gen_context=gen_context,
         )
-
-    async def _run_archive_task(
-        self,
-        memory_task: MemoryGenerationTask,
-        gen_context: "GenerationContext",
-    ) -> None:
-        """Mode A 后台执行体。"""
-        memory_task.status = MemoryGenerationTaskStatus.RUNNING
-        if memory_task.cancelled:
-            memory_task.status = MemoryGenerationTaskStatus.CANCELLED
-            memory_task.finished_at = datetime.now(timezone.utc)
-            await self._publish_memory_task_status(memory_task)
-            return
-
-        memory_task.started_at = datetime.now(timezone.utc)
-        await self._publish_memory_task_status(memory_task)
-
-        try:
-            logger.info(f"LibrarianCore Mode A: {len(gen_context.turns)} 轮对话...")
-            request = GenerationRequest(context=gen_context)
-            results = await self._run_generation(request)
-            self._backfill_memory_task_result(memory_task, results)
-            memory_task.status = MemoryGenerationTaskStatus.COMPLETED
-        except asyncio.CancelledError:
-            memory_task.status = MemoryGenerationTaskStatus.CANCELLED
-            raise
-        except Exception as e:
-            logger.error(f"感知层 Flush 处理失败: {e}", exc_info=True)
-            memory_task.status = MemoryGenerationTaskStatus.FAILED
-            memory_task.error = str(e)
-        finally:
-            memory_task.finished_at = datetime.now(timezone.utc)
-            await self._publish_memory_task_status(memory_task)
 
     async def run_active_generation(
         self,
-        tasks: List["PendingAtomMaterializeTask"],
+        tasks: List[PendingAtomMaterializeTask],
         topic_id: str,
     ) -> List[MemoryGenerationTask]:
-        """MTP WRITE/UPDATE 主动链路入口 — 后台异步执行，立即返回。
-
-        按 §3.3 时序在 submit_interaction 之后调用，此时当前轮对话 block
-        已在 buffer，故 topic_context 包含「刚刚这轮」作为只读背景。
-        """
-        memory_tasks = []
-        for task in tasks:
-            memory_tasks.append(
-                await self._create_and_run_task(
-                    topic_id=topic_id,
-                    label=task.pending_alias,
-                    source=MemoryGenerationSource(task.source_verb),
-                    pending_alias=task.pending_alias,
-                    coro_factory=lambda mt, t=task: self._run_active_task(mt, t, topic_id),
-                )
-            )
-        return memory_tasks
-
-    async def _run_active_task(
-        self,
-        memory_task: MemoryGenerationTask,
-        task: "PendingAtomMaterializeTask",
-        topic_id: str,
-    ) -> None:
-        """MTP 主动链路后台执行体 — 处理单个生成任务。"""
-        memory_task.status = MemoryGenerationTaskStatus.RUNNING
-
-        if memory_task.cancelled:
-            memory_task.status = MemoryGenerationTaskStatus.CANCELLED
-            memory_task.finished_at = datetime.now(timezone.utc)
-            await self._publish_pending_atom_cancelled(task.pending_alias)
-            await self._publish_memory_task_status(memory_task)
-            return
+        """Run MTP WRITE/UPDATE memory generation tasks in the background."""
+        if not tasks:
+            return []
 
         topic_context: Dict[str, Any] = {"state_summary": "", "blocks": []}
         if self.perception_layer is not None:
@@ -306,213 +163,20 @@ class LibrarianCore:
             topic_context.get("blocks", []),
             topic_context.get("state_summary", ""),
         )
-
-        if memory_task.cancelled:
-            memory_task.status = MemoryGenerationTaskStatus.CANCELLED
-            memory_task.finished_at = datetime.now(timezone.utc)
-            await self._publish_pending_atom_cancelled(task.pending_alias)
-            await self._publish_memory_task_status(memory_task)
-            return
-
-        memory_task.started_at = datetime.now(timezone.utc)
-        await self._publish_memory_task_status(memory_task)
-
-        try:
-            if task.source_verb == "WRITE":
-                results = await self._run_mode_b(task, gen_context)
-            else:
-                results = await self._run_mode_c(task, gen_context)
-            self._backfill_memory_task_result(
-                memory_task,
-                results,
-                pending_alias=task.pending_alias,
-            )
-            memory_task.status = MemoryGenerationTaskStatus.COMPLETED
-        except asyncio.CancelledError:
-            memory_task.status = MemoryGenerationTaskStatus.CANCELLED
-            await self._publish_pending_atom_cancelled(task.pending_alias)
-            raise
-        except Exception as e:
-            logger.error(
-                f"主动生成失败: pending_alias={task.pending_alias}, err={e}",
-                exc_info=True,
-            )
-            memory_task.status = MemoryGenerationTaskStatus.FAILED
-            memory_task.error = str(e)
-            await self._publish_pending_atom_failed(task.pending_alias)
-        finally:
-            memory_task.finished_at = datetime.now(timezone.utc)
-            await self._publish_memory_task_status(memory_task)
-
-    async def _run_mode_b(
-        self,
-        task: "PendingAtomMaterializeTask",
-        gen_context: "GenerationContext",
-    ) -> List[MemoryGenerationResult]:
-        """Mode B: WRITE 指令定向记忆生成。"""
-        from hivememory.core.models.pending import WriteFocus
-        focus = task.focus
-        assert isinstance(focus, WriteFocus)
-        logger.info(f"Mode B WRITE: content='{focus.content[:50]}...'")
-        request = GenerationRequest(
-            context=gen_context,
-            write_focus=focus,
-            identity=task.identity,
-            intent_id=task.intent_id,
-            pending_alias=task.pending_alias,
+        return await self._memory_task_controller.run_active_generation(
+            tasks,
+            topic_id,
+            gen_context=gen_context,
         )
-        return await self._run_generation(request)
-
-    async def _run_mode_c(
-        self,
-        task: "PendingAtomMaterializeTask",
-        gen_context: "GenerationContext",
-    ) -> List[MemoryGenerationResult]:
-        """Mode C: UPDATE 指令定向记忆更新。"""
-        from uuid import UUID as _UUID
-        from hivememory.core.models.pending import UpdateFocus
-        focus = task.focus
-        assert isinstance(focus, UpdateFocus)
-        logger.info(f"Mode C UPDATE: alias='{focus.base_alias}'")
-
-        existing_result = self.storage.get_memory(_UUID(focus.base_uuid))
-        existing = (
-            await existing_result if inspect.isawaitable(existing_result)
-            else existing_result
-        )
-        if existing is None:
-            logger.error(f"UPDATE 目标记忆不存在: {focus.base_uuid}")
-            raise RuntimeError(f"UPDATE target memory not found: {focus.base_uuid}")
-
-        request = GenerationRequest(
-            context=gen_context,
-            update_focus=focus,
-            existing_memory=existing,
-            identity=task.identity,
-            intent_id=task.intent_id,
-            pending_alias=task.pending_alias,
-        )
-        return await self._run_generation(request)
-
-    async def _run_generation(self, request: "GenerationRequest") -> List[MemoryGenerationResult]:
-        """调用生成引擎并发布 Settlement 事件。"""
-        process_result = self.generation_engine.process(request)
-        results = (
-            await process_result if inspect.isawaitable(process_result)
-            else process_result
-        )
-
-        memories = [r.atom for r in results if r.atom is not None]
-        logger.info(f"成功提取 {len(memories)} 条记忆" if memories else "未提取到记忆")
-
-        if self._bus is not None:
-            for r in results:
-                if r.settlement is not None:
-                    try:
-                        await self._bus.publish(
-                            PatchouliLocalEvents.PENDING_ATOM_SETTLED,
-                            settlement=r.settlement,
-                        )
-                    except Exception as pub_err:
-                        logger.warning(
-                            f"Settlement publish failed for "
-                            f"{r.settlement.pending_alias}: {pub_err}"
-                        )
-                        await self._publish_pending_atom_failed(r.settlement.pending_alias)
-
-        return results
-
-    def _backfill_memory_task_result(
-        self,
-        memory_task: MemoryGenerationTask,
-        results: List[MemoryGenerationResult],
-        pending_alias: Optional[str] = None,
-    ) -> None:
-        canonical_alias = self._select_canonical_alias(
-            results,
-            pending_alias=pending_alias,
-        )
-        if canonical_alias:
-            memory_task.canonical_alias = canonical_alias
-
-    def _select_canonical_alias(
-        self,
-        results: List[MemoryGenerationResult],
-        pending_alias: Optional[str] = None,
-    ) -> Optional[str]:
-        candidates = results
-        if pending_alias:
-            matched = [
-                result for result in results
-                if result.pending_alias == pending_alias
-                or (
-                    result.settlement is not None
-                    and result.settlement.pending_alias == pending_alias
-                )
-            ]
-            if matched:
-                candidates = matched
-
-        for result in candidates:
-            if result.settlement is not None and result.settlement.canonical_alias:
-                return result.settlement.canonical_alias
-            if result.canonical_alias:
-                return result.canonical_alias
-            if result.atom is not None:
-                get_alias = getattr(result.atom, "get_alias", None)
-                if callable(get_alias):
-                    alias = get_alias()
-                    if alias:
-                        return alias
-        return None
-
-    async def _publish_pending_atom_cancelled(self, pending_alias: str) -> None:
-        if self._bus is None:
-            return
-        try:
-            await self._bus.publish(
-                PatchouliLocalEvents.PENDING_ATOM_CANCELLED,
-                pending_alias=pending_alias,
-            )
-        except Exception as pub_err:
-            logger.warning(f"CANCELLED event publish error: {pub_err}")
-    
-    async def _publish_pending_atom_failed(self, pending_alias: str) -> None:
-        """Publish FAILED event for an active materialization task."""
-        if self._bus is None:
-            return
-        try:
-            await self._bus.publish(
-                PatchouliLocalEvents.PENDING_ATOM_FAILED,
-                pending_alias=pending_alias,
-            )
-        except Exception as pub_err:
-            logger.warning(f"FAILED event publish error: {pub_err}")
-
-    # ========== Task 查询 API ==========
-
-    async def _publish_memory_task_status(self, memory_task: MemoryGenerationTask) -> None:
-        if self._bus is None:
-            return
-        try:
-            await self._bus.publish(
-                PatchouliLocalEvents.MEMORY_TASK_ITEM_STATUS,
-                task_id=memory_task.task_id,
-                pending_alias=memory_task.pending_alias,
-                status=memory_task.status.value,
-                canonical_alias=memory_task.canonical_alias,
-            )
-        except Exception as pub_err:
-            logger.warning(f"MEMORY_TASK_ITEM_STATUS publish error: {pub_err}")
 
     def get_task(self, task_id: str) -> Optional[MemoryGenerationTask]:
-        return self._task_registry.get(task_id)
+        return self._memory_task_controller.get_task(task_id)
 
     def list_tasks(self) -> List[MemoryGenerationTask]:
-        return self._task_registry.list_all()
+        return self._memory_task_controller.list_tasks()
 
     def cancel_task(self, task_id: str) -> bool:
-        return self._task_registry.cancel(task_id)
+        return self._memory_task_controller.cancel_task(task_id)
 
     def _build_generation_context(
         self,
@@ -609,13 +273,6 @@ class LibrarianCore:
             "message": "perception_layer 未注入",
             "blocks_archived": 0,
         }
-
-    async def manual_trigger(
-        self,
-        topic_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """兼容别名：旧代码仍可通过 manual_trigger 调用。"""
-        return await self.manual_archive_topic(topic_id)
 
     async def prepare_topic(
         self,

--- a/src/hivememory/patchouli/services/memory_generation_tasks.py
+++ b/src/hivememory/patchouli/services/memory_generation_tasks.py
@@ -1,0 +1,469 @@
+"""
+记忆生成任务控制器 (Memory Generation Task Controller)
+
+定位：Patchouli 的 Phase 2 运行时任务控制面。
+
+职责：
+    - 统一创建、注册和调度 MemoryGenerationTask
+    - 承接主动 WRITE/UPDATE 与被动 ARCHIVE 两类记忆生成链路
+    - 发布任务状态、PendingAtom 结算/失败/取消事件
+    - 在生成结果返回后回填 MemoryGenerationTask.canonical_alias
+    - 提供 task 查询与取消 API
+
+该模块从 LibrarianCore 中拆出。LibrarianCore 保留协调入口职责，
+本模块专注于“记忆生成任务”的生命周期、可观测性和控制流。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Callable, List, Optional
+
+from hivememory.core.models.pending import PendingAtomMaterializeTask
+from hivememory.engines.generation.models import (
+    GenerationContext,
+    GenerationRequest,
+    MemoryGenerationResult,
+)
+from hivememory.patchouli.contracts.local_events import PatchouliLocalEvents
+from hivememory.system.runtime.control import (
+    MemoryGenerationSource,
+    MemoryGenerationTask,
+    MemoryGenerationTaskRegistry,
+    MemoryGenerationTaskStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryGenerationTaskController:
+    """
+    记忆生成任务控制器。
+
+    这是 Phase 2 任务运行时的集中入口。它不负责感知层路由和生命周期
+    gardening，只负责把已经确定要执行的记忆生成请求包装为可观测、可取消、
+    可查询的 MemoryGenerationTask。
+    """
+
+    def __init__(
+        self,
+        *,
+        storage: Any,
+        bus: Optional[Any] = None,
+        generation_engine: Optional[Any] = None,
+        task_registry: Optional[MemoryGenerationTaskRegistry] = None,
+    ) -> None:
+        self.storage = storage
+        self._bus = bus
+        self.generation_engine = generation_engine
+        self._task_registry = task_registry or MemoryGenerationTaskRegistry()
+
+    async def run_archive_generation(
+        self,
+        topic_id: str,
+        gen_context: GenerationContext,
+    ) -> MemoryGenerationTask:
+        """启动被动归档链路的记忆生成任务。"""
+        return await self._create_and_run_task(
+            topic_id=topic_id,
+            label=topic_id,
+            source=MemoryGenerationSource.ARCHIVE,
+            coro_factory=lambda mt: self._run_archive_task(mt, gen_context),
+        )
+
+    async def run_active_generation(
+        self,
+        tasks: List[PendingAtomMaterializeTask],
+        topic_id: str,
+        *,
+        gen_context: GenerationContext,
+    ) -> List[MemoryGenerationTask]:
+        """启动 MTP WRITE/UPDATE 主动链路的记忆生成任务。"""
+        memory_tasks = []
+        for task in tasks:
+            memory_tasks.append(
+                await self._create_and_run_task(
+                    topic_id=topic_id,
+                    label=task.pending_alias,
+                    source=MemoryGenerationSource(task.source_verb),
+                    pending_alias=task.pending_alias,
+                    coro_factory=lambda mt, t=task: self._run_active_task(mt, t, gen_context),
+                )
+            )
+        return memory_tasks
+
+    async def _create_and_run_task(
+        self,
+        topic_id: str,
+        label: str,
+        source: MemoryGenerationSource,
+        coro_factory: Callable[[MemoryGenerationTask], Any],
+        pending_alias: Optional[str] = None,
+        skip: bool = False,
+    ) -> MemoryGenerationTask:
+        """
+        统一任务工厂：创建运行时句柄、注册任务、绑定后台协程。
+
+        返回值必须立即可用，后台生成通过 memory_task._bg_task 继续执行。
+        这保证上层可以先把 task_id 暴露给前端，再由控制面处理取消和状态观察。
+        """
+        memory_task = MemoryGenerationTask(
+            task_id=str(uuid.uuid4()),
+            topic_id=topic_id,
+            label=label,
+            source=source,
+            pending_alias=pending_alias,
+        )
+        self._task_registry.register(memory_task)
+
+        # 没有生成引擎时仍返回一个已完成 task，保持调用方契约稳定。
+        if skip or self.generation_engine is None:
+            self._task_registry.close(memory_task.task_id, MemoryGenerationTaskStatus.COMPLETED)
+            return memory_task
+
+        bg_task = asyncio.create_task(
+            coro_factory(memory_task),
+            name=f"memory_task_{memory_task.task_id[:8]}",
+        )
+        memory_task.attach_task(bg_task)
+
+        def _terminal_status() -> MemoryGenerationTaskStatus:
+            if memory_task.cancelled or memory_task.status == MemoryGenerationTaskStatus.CANCELLED:
+                return MemoryGenerationTaskStatus.CANCELLED
+            if memory_task.status == MemoryGenerationTaskStatus.FAILED:
+                return MemoryGenerationTaskStatus.FAILED
+            return MemoryGenerationTaskStatus.COMPLETED
+
+        def _mark_task_cancelled() -> None:
+            if memory_task.status not in (
+                MemoryGenerationTaskStatus.COMPLETED,
+                MemoryGenerationTaskStatus.FAILED,
+                MemoryGenerationTaskStatus.CANCELLED,
+            ):
+                memory_task.status = MemoryGenerationTaskStatus.CANCELLED
+
+        def _schedule_terminal_status_publish(status: MemoryGenerationTaskStatus) -> None:
+            if memory_task.finished_at is not None or self._bus is None:
+                return
+            memory_task.status = status
+            memory_task.finished_at = datetime.now(timezone.utc)
+            asyncio.create_task(
+                self._publish_memory_task_status(memory_task),
+                name=f"memory_task_status_{memory_task.task_id[:8]}",
+            )
+
+        def _done_callback(t: asyncio.Task) -> None:
+            # 后台 task 被外部 cancel 时，补齐 registry 与实时状态事件。
+            if t.cancelled():
+                _mark_task_cancelled()
+                _schedule_terminal_status_publish(MemoryGenerationTaskStatus.CANCELLED)
+                self._task_registry.close(memory_task.task_id, MemoryGenerationTaskStatus.CANCELLED)
+                return
+
+            exc = t.exception()
+            if memory_task.cancelled:
+                _mark_task_cancelled()
+                _schedule_terminal_status_publish(MemoryGenerationTaskStatus.CANCELLED)
+                self._task_registry.close(memory_task.task_id, MemoryGenerationTaskStatus.CANCELLED)
+            elif exc is not None:
+                logger.error(f"memory task {memory_task.task_id} failed: {exc}", exc_info=exc)
+                _schedule_terminal_status_publish(MemoryGenerationTaskStatus.FAILED)
+                self._task_registry.close(memory_task.task_id, MemoryGenerationTaskStatus.FAILED)
+            else:
+                self._task_registry.close(memory_task.task_id, _terminal_status())
+
+        bg_task.add_done_callback(_done_callback)
+        return memory_task
+
+    async def _run_archive_task(
+        self,
+        memory_task: MemoryGenerationTask,
+        gen_context: GenerationContext,
+    ) -> None:
+        """执行被动 ARCHIVE 生成链路，并在终态前回填任务结果。"""
+        memory_task.status = MemoryGenerationTaskStatus.RUNNING
+        if memory_task.cancelled:
+            memory_task.status = MemoryGenerationTaskStatus.CANCELLED
+            memory_task.finished_at = datetime.now(timezone.utc)
+            await self._publish_memory_task_status(memory_task)
+            return
+
+        memory_task.started_at = datetime.now(timezone.utc)
+        await self._publish_memory_task_status(memory_task)
+
+        try:
+            logger.info(f"Memory generation archive task: {len(gen_context.turns)} turns")
+            request = GenerationRequest(context=gen_context)
+            results = await self._run_generation(request)
+            # 被动链路可能产出多条记忆；Phase 2 先回填第一条可用 canonical_alias。
+            self._backfill_memory_task_result(memory_task, results)
+            memory_task.status = MemoryGenerationTaskStatus.COMPLETED
+        except asyncio.CancelledError:
+            memory_task.status = MemoryGenerationTaskStatus.CANCELLED
+            raise
+        except Exception as e:
+            logger.error(f"Archive memory generation failed: {e}", exc_info=True)
+            memory_task.status = MemoryGenerationTaskStatus.FAILED
+            memory_task.error = str(e)
+        finally:
+            memory_task.finished_at = datetime.now(timezone.utc)
+            await self._publish_memory_task_status(memory_task)
+
+    async def _run_active_task(
+        self,
+        memory_task: MemoryGenerationTask,
+        task: PendingAtomMaterializeTask,
+        gen_context: GenerationContext,
+    ) -> None:
+        """执行单个 MTP WRITE/UPDATE 主动生成任务。"""
+        memory_task.status = MemoryGenerationTaskStatus.RUNNING
+
+        if memory_task.cancelled:
+            memory_task.status = MemoryGenerationTaskStatus.CANCELLED
+            memory_task.finished_at = datetime.now(timezone.utc)
+            await self._publish_pending_atom_cancelled(task.pending_alias)
+            await self._publish_memory_task_status(memory_task)
+            return
+
+        if memory_task.cancelled:
+            memory_task.status = MemoryGenerationTaskStatus.CANCELLED
+            memory_task.finished_at = datetime.now(timezone.utc)
+            await self._publish_pending_atom_cancelled(task.pending_alias)
+            await self._publish_memory_task_status(memory_task)
+            return
+
+        memory_task.started_at = datetime.now(timezone.utc)
+        await self._publish_memory_task_status(memory_task)
+
+        try:
+            if task.source_verb == "WRITE":
+                results = await self._run_mode_b(task, gen_context)
+            else:
+                results = await self._run_mode_c(task, gen_context)
+            # 主动链路优先按 pending_alias 匹配结果，避免多 result 时串到其他任务。
+            self._backfill_memory_task_result(
+                memory_task,
+                results,
+                pending_alias=task.pending_alias,
+            )
+            memory_task.status = MemoryGenerationTaskStatus.COMPLETED
+        except asyncio.CancelledError:
+            memory_task.status = MemoryGenerationTaskStatus.CANCELLED
+            await self._publish_pending_atom_cancelled(task.pending_alias)
+            raise
+        except Exception as e:
+            logger.error(
+                f"Active memory generation failed: pending_alias={task.pending_alias}, err={e}",
+                exc_info=True,
+            )
+            memory_task.status = MemoryGenerationTaskStatus.FAILED
+            memory_task.error = str(e)
+            await self._publish_pending_atom_failed(task.pending_alias)
+        finally:
+            memory_task.finished_at = datetime.now(timezone.utc)
+            await self._publish_memory_task_status(memory_task)
+
+    async def _run_mode_b(
+        self,
+        task: PendingAtomMaterializeTask,
+        gen_context: GenerationContext,
+    ) -> List[MemoryGenerationResult]:
+        """Mode B：将 MTP WRITE 请求转换为 GenerationRequest。"""
+        from hivememory.core.models.pending import WriteFocus
+
+        focus = task.focus
+        assert isinstance(focus, WriteFocus)
+        logger.info(f"Mode B WRITE: content='{focus.content[:50]}...'")
+        request = GenerationRequest(
+            context=gen_context,
+            write_focus=focus,
+            identity=task.identity,
+            intent_id=task.intent_id,
+            pending_alias=task.pending_alias,
+        )
+        return await self._run_generation(request)
+
+    async def _run_mode_c(
+        self,
+        task: PendingAtomMaterializeTask,
+        gen_context: GenerationContext,
+    ) -> List[MemoryGenerationResult]:
+        """Mode C：加载 UPDATE 目标记忆，并转换为 GenerationRequest。"""
+        from uuid import UUID as _UUID
+
+        from hivememory.core.models.pending import UpdateFocus
+
+        focus = task.focus
+        assert isinstance(focus, UpdateFocus)
+        logger.info(f"Mode C UPDATE: alias='{focus.base_alias}'")
+
+        existing_result = self.storage.get_memory(_UUID(focus.base_uuid))
+        existing = (
+            await existing_result if inspect.isawaitable(existing_result)
+            else existing_result
+        )
+        if existing is None:
+            logger.error(f"UPDATE target memory not found: {focus.base_uuid}")
+            raise RuntimeError(f"UPDATE target memory not found: {focus.base_uuid}")
+
+        request = GenerationRequest(
+            context=gen_context,
+            update_focus=focus,
+            existing_memory=existing,
+            identity=task.identity,
+            intent_id=task.intent_id,
+            pending_alias=task.pending_alias,
+        )
+        return await self._run_generation(request)
+
+    async def _run_generation(self, request: GenerationRequest) -> List[MemoryGenerationResult]:
+        """
+        调用生成引擎并发布 PendingAtom settlement 事件。
+
+        返回结构化 MemoryGenerationResult，供任务终态前回填 canonical_alias。
+        """
+        process_result = self.generation_engine.process(request)
+        results = (
+            await process_result if inspect.isawaitable(process_result)
+            else process_result
+        )
+
+        memories = [r.atom for r in results if r.atom is not None]
+        logger.info(
+            f"Extracted {len(memories)} memories"
+            if memories
+            else "No memories extracted"
+        )
+
+        if self._bus is not None:
+            for result in results:
+                if result.settlement is not None:
+                    # Settlement 是主动 WRITE/UPDATE 与 Alice PendingAtomRuntime 的应答桥。
+                    try:
+                        await self._bus.publish(
+                            PatchouliLocalEvents.PENDING_ATOM_SETTLED,
+                            settlement=result.settlement,
+                        )
+                    except Exception as pub_err:
+                        logger.warning(
+                            f"Settlement publish failed for "
+                            f"{result.settlement.pending_alias}: {pub_err}"
+                        )
+                        await self._publish_pending_atom_failed(
+                            result.settlement.pending_alias
+                        )
+
+        return results
+
+    def _backfill_memory_task_result(
+        self,
+        memory_task: MemoryGenerationTask,
+        results: List[MemoryGenerationResult],
+        pending_alias: Optional[str] = None,
+    ) -> None:
+        """从生成结果中选择 canonical_alias，并写回运行时任务句柄。"""
+        canonical_alias = self._select_canonical_alias(
+            results,
+            pending_alias=pending_alias,
+        )
+        if canonical_alias:
+            memory_task.canonical_alias = canonical_alias
+
+    def _select_canonical_alias(
+        self,
+        results: List[MemoryGenerationResult],
+        pending_alias: Optional[str] = None,
+    ) -> Optional[str]:
+        """
+        选择任务展示用的 canonical_alias。
+
+        优先级：
+            1. settlement.canonical_alias
+            2. result.canonical_alias
+            3. result.atom.get_alias()
+
+        主动链路会优先匹配 pending_alias；被动链路取第一条可用结果。
+        """
+        candidates = results
+        if pending_alias:
+            matched = [
+                result for result in results
+                if result.pending_alias == pending_alias
+                or (
+                    result.settlement is not None
+                    and result.settlement.pending_alias == pending_alias
+                )
+            ]
+            if matched:
+                candidates = matched
+
+        for result in candidates:
+            if result.settlement is not None and result.settlement.canonical_alias:
+                return result.settlement.canonical_alias
+            if result.canonical_alias:
+                return result.canonical_alias
+            if result.atom is not None:
+                get_alias = getattr(result.atom, "get_alias", None)
+                if callable(get_alias):
+                    alias = get_alias()
+                    if alias:
+                        return alias
+        return None
+
+    async def _publish_pending_atom_cancelled(self, pending_alias: str) -> None:
+        """发布主动链路 PendingAtom 取消事件。"""
+        if self._bus is None:
+            return
+        try:
+            await self._bus.publish(
+                PatchouliLocalEvents.PENDING_ATOM_CANCELLED,
+                pending_alias=pending_alias,
+            )
+        except Exception as pub_err:
+            logger.warning(f"CANCELLED event publish error: {pub_err}")
+
+    async def _publish_pending_atom_failed(self, pending_alias: str) -> None:
+        """发布主动链路 PendingAtom 失败事件。"""
+        if self._bus is None:
+            return
+        try:
+            await self._bus.publish(
+                PatchouliLocalEvents.PENDING_ATOM_FAILED,
+                pending_alias=pending_alias,
+            )
+        except Exception as pub_err:
+            logger.warning(f"FAILED event publish error: {pub_err}")
+
+    async def _publish_memory_task_status(self, memory_task: MemoryGenerationTask) -> None:
+        """发布 MemoryGenerationTask 的实时状态快照。"""
+        if self._bus is None:
+            return
+        try:
+            await self._bus.publish(
+                PatchouliLocalEvents.MEMORY_TASK_ITEM_STATUS,
+                task_id=memory_task.task_id,
+                pending_alias=memory_task.pending_alias,
+                status=memory_task.status.value,
+                canonical_alias=memory_task.canonical_alias,
+            )
+        except Exception as pub_err:
+            logger.warning(f"MEMORY_TASK_ITEM_STATUS publish error: {pub_err}")
+
+    def get_task(self, task_id: str) -> Optional[MemoryGenerationTask]:
+        """按 task_id 查询运行时任务。"""
+        return self._task_registry.get(task_id)
+
+    def list_tasks(self) -> List[MemoryGenerationTask]:
+        """列出当前 registry 中仍保留的任务。"""
+        return self._task_registry.list_all()
+
+    def cancel_task(self, task_id: str) -> bool:
+        """请求取消指定记忆生成任务。"""
+        return self._task_registry.cancel(task_id)
+
+
+__all__ = ["MemoryGenerationTaskController"]

--- a/tests/unit/patchouli/services/test_librarian.py
+++ b/tests/unit/patchouli/services/test_librarian.py
@@ -107,15 +107,15 @@ class TestLibrarianCorePerceptionDelegation:
         self.perception.get_active_topics_snapshots.assert_called_once_with(identity)
 
     @pytest.mark.asyncio
-    async def test_manual_trigger(self):
-        result = await self.core.manual_trigger("topic_1")
+    async def test_manual_archive_topic(self):
+        result = await self.core.manual_archive_topic("topic_1")
         assert result["success"] is True
         self.perception.manual_trigger.assert_called_once_with("topic_1")
 
     @pytest.mark.asyncio
-    async def test_manual_trigger_without_perception(self):
+    async def test_manual_archive_topic_without_perception(self):
         core = LibrarianCore(storage=Mock(), perception_layer=None)
-        result = await core.manual_trigger("topic_x")
+        result = await core.manual_archive_topic("topic_x")
         assert result["success"] is False
 
 
@@ -169,6 +169,34 @@ class TestLibrarianCoreGenerateMemory:
             generation_engine=self.mock_generation,
         )
 
+    def _core_with_context(self, blocks=None, bus=None):
+        perception_layer = Mock()
+        perception_layer.get_topic_context.return_value = {
+            "state_summary": "",
+            "blocks": blocks if blocks is not None else [],
+        }
+        core = LibrarianCore(
+            storage=self.mock_storage,
+            bus=bus,
+            generation_engine=self.mock_generation,
+            perception_layer=perception_layer,
+        )
+        return core
+
+    @pytest.mark.asyncio
+    async def test_run_active_generation_empty_tasks_skips_context_lookup(self):
+        perception_layer = Mock()
+        core = LibrarianCore(
+            storage=self.mock_storage,
+            generation_engine=self.mock_generation,
+            perception_layer=perception_layer,
+        )
+
+        memory_tasks = await core.run_active_generation([], topic_id="topic_test")
+
+        assert memory_tasks == []
+        perception_layer.get_topic_context.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_generate_memory_mode_a_default(self):
         """普通 flush，Phase 3: 构建 GenerationRequest(context=GenerationContext)"""
@@ -201,11 +229,7 @@ class TestLibrarianCoreGenerateMemory:
         """主动 WRITE 由 finalize 直驱 run_active_generation"""
         blocks = _make_logical_blocks(2)
         write_focus = WriteFocus(content="测试写入内容")
-        self.core.perception_layer = Mock()
-        self.core.perception_layer.get_topic_context.return_value = {
-            "state_summary": "",
-            "blocks": blocks,
-        }
+        core = self._core_with_context(blocks)
         task = PendingAtomMaterializeTask(
             pending_alias="draft_test_001",
             intent_id="intent_test_001",
@@ -214,7 +238,7 @@ class TestLibrarianCoreGenerateMemory:
             focus=write_focus,
         )
 
-        memory_tasks = await self.core.run_active_generation([task], topic_id="topic_test")
+        memory_tasks = await core.run_active_generation([task], topic_id="topic_test")
         _memory_task = memory_tasks[0]
 
         if _memory_task._bg_task:
@@ -231,11 +255,7 @@ class TestLibrarianCoreGenerateMemory:
     async def test_generate_memory_mode_b_write_without_context_still_runs(self):
         """主动 WRITE 不依赖上下文轮次，空背景也应进入 generation fallback"""
         write_focus = WriteFocus(content="测试写入内容")
-        self.core.perception_layer = Mock()
-        self.core.perception_layer.get_topic_context.return_value = {
-            "state_summary": "",
-            "blocks": [],
-        }
+        core = self._core_with_context([])
         task = PendingAtomMaterializeTask(
             pending_alias="draft_test_002",
             intent_id="intent_test_002",
@@ -244,7 +264,7 @@ class TestLibrarianCoreGenerateMemory:
             focus=write_focus,
         )
 
-        memory_tasks = await self.core.run_active_generation([task], topic_id="topic_test")
+        memory_tasks = await core.run_active_generation([task], topic_id="topic_test")
         _memory_task = memory_tasks[0]
 
         if _memory_task._bg_task:
@@ -269,11 +289,7 @@ class TestLibrarianCoreGenerateMemory:
             base_alias="fact_test",
         )
         existing_memory = Mock()
-        self.core.perception_layer = Mock()
-        self.core.perception_layer.get_topic_context.return_value = {
-            "state_summary": "",
-            "blocks": blocks,
-        }
+        core = self._core_with_context(blocks)
         task = PendingAtomMaterializeTask(
             pending_alias="rev_test_001",
             intent_id="intent_test_003",
@@ -284,7 +300,7 @@ class TestLibrarianCoreGenerateMemory:
 
         self.mock_storage.get_memory = AsyncMock(return_value=existing_memory)
 
-        memory_tasks = await self.core.run_active_generation([task], topic_id="topic_test")
+        memory_tasks = await core.run_active_generation([task], topic_id="topic_test")
         _memory_task = memory_tasks[0]
 
         if _memory_task._bg_task:
@@ -305,11 +321,7 @@ class TestLibrarianCoreGenerateMemory:
             base_alias="fact_test",
         )
         existing_memory = Mock()
-        self.core.perception_layer = Mock()
-        self.core.perception_layer.get_topic_context.return_value = {
-            "state_summary": "",
-            "blocks": [],
-        }
+        core = self._core_with_context([])
         task = PendingAtomMaterializeTask(
             pending_alias="rev_test_002",
             intent_id="intent_test_004",
@@ -319,7 +331,7 @@ class TestLibrarianCoreGenerateMemory:
         )
         self.mock_storage.get_memory = AsyncMock(return_value=existing_memory)
 
-        memory_tasks = await self.core.run_active_generation([task], topic_id="topic_test")
+        memory_tasks = await core.run_active_generation([task], topic_id="topic_test")
         _memory_task = memory_tasks[0]
 
         if _memory_task._bg_task:
@@ -343,11 +355,8 @@ class TestLibrarianCoreGenerateMemory:
             base_uuid=str(uuid4()),
             base_alias="fact_test",
         )
-        self.core.perception_layer = Mock()
-        self.core.perception_layer.get_topic_context.return_value = {
-            "state_summary": "",
-            "blocks": blocks,
-        }
+        bus = AsyncMock()
+        core = self._core_with_context(blocks, bus=bus)
         task = PendingAtomMaterializeTask(
             pending_alias="rev_test_003",
             intent_id="intent_test_005",
@@ -357,9 +366,8 @@ class TestLibrarianCoreGenerateMemory:
         )
 
         self.mock_storage.get_memory = AsyncMock(return_value=None)
-        self.core._bus = AsyncMock()
 
-        memory_tasks = await self.core.run_active_generation([task], topic_id="topic_test")
+        memory_tasks = await core.run_active_generation([task], topic_id="topic_test")
         _memory_task = memory_tasks[0]
 
         if _memory_task._bg_task:
@@ -369,8 +377,8 @@ class TestLibrarianCoreGenerateMemory:
 
         self.mock_generation.process.assert_not_called()
         # Phase 2: status running -> PENDING_ATOM_FAILED -> status failed
-        assert self.core._bus.publish.await_count >= 1
-        last_call_kwargs = self.core._bus.publish.await_args.kwargs
+        assert bus.publish.await_count >= 1
+        last_call_kwargs = bus.publish.await_args.kwargs
         assert last_call_kwargs["pending_alias"] == "rev_test_003"
 
     @pytest.mark.asyncio
@@ -407,21 +415,22 @@ class TestLibrarianCoreGenerateMemory:
                 )
             ]
         )
-        self.core._bus = AsyncMock()
+        bus = AsyncMock()
         # Phase 2: status running → PENDING_ATOM_SETTLED (fails) → PENDING_ATOM_FAILED → status completed
-        self.core._bus.publish = AsyncMock(
+        bus.publish = AsyncMock(
             side_effect=[None, RuntimeError("publish failed"), None, None]
         )
 
-        memory_tasks = await self.core.run_active_generation([task], topic_id="topic_test")
+        core = self._core_with_context([], bus=bus)
+        memory_tasks = await core.run_active_generation([task], topic_id="topic_test")
         _memory_task = memory_tasks[0]
 
         if _memory_task._bg_task:
 
             await _memory_task._bg_task
 
-        assert self.core._bus.publish.await_count == 4
-        calls = self.core._bus.publish.await_args_list
+        assert bus.publish.await_count == 4
+        calls = bus.publish.await_args_list
         memory_statuses = [
             call.kwargs["status"]
             for call in calls
@@ -735,11 +744,7 @@ class TestLibrarianCoreGenerateMemory:
     @pytest.mark.asyncio
     async def test_run_active_generation_uses_task_identity(self):
         write_focus = WriteFocus(content="测试写入内容")
-        self.core.perception_layer = Mock()
-        self.core.perception_layer.get_topic_context.return_value = {
-            "state_summary": "",
-            "blocks": [],
-        }
+        core = self._core_with_context([])
         identity = _make_identity()
         task = PendingAtomMaterializeTask(
             pending_alias="draft_test_003",
@@ -749,7 +754,7 @@ class TestLibrarianCoreGenerateMemory:
             focus=write_focus,
         )
 
-        memory_tasks = await self.core.run_active_generation([task], topic_id="topic_test")
+        memory_tasks = await core.run_active_generation([task], topic_id="topic_test")
         _memory_task = memory_tasks[0]
 
         if _memory_task._bg_task:

--- a/tests/unit/patchouli/services/test_memory_generation_task.py
+++ b/tests/unit/patchouli/services/test_memory_generation_task.py
@@ -24,16 +24,17 @@ def _make_core(mock_generation=None, mock_storage=None, bus=None):
     gen.process.return_value = []
     storage = mock_storage or MagicMock()
     storage.get_memory = AsyncMock(return_value=MagicMock())
+    perception_layer = MagicMock()
+    perception_layer.get_topic_context.return_value = {
+        "state_summary": "",
+        "blocks": [],
+    }
     core = LibrarianCore(
         storage=storage,
         bus=bus or AsyncMock(),
         generation_engine=gen,
+        perception_layer=perception_layer,
     )
-    core.perception_layer = MagicMock()
-    core.perception_layer.get_topic_context.return_value = {
-        "state_summary": "",
-        "blocks": [],
-    }
     return core, gen
 
 


### PR DESCRIPTION
## 描述

拆分MemoryGenerationTask至单独编排组件，降低LibrarianCore职责负担

## 类型

- [ ] Bug 修复 (fix)
- [ ] 新功能 (feat)
- [x] 代码重构 (refactor)
- [ ] 文档更新 (docs)
- [ ] 代码风格更新 (style)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 构建/CI 更新 (build/ci)
- [ ] 其他变更 (chore)

## 相关 Issue

无

## 检查清单

- [x] 我已经阅读了项目的贡献指南
- [x] 我已经自我审查了代码，并确保其符合项目的代码风格与规范
- [x] 代码通过了 lint 检查
- [x] 添加了必要的测试用例并全部通过
- [x] 文档已更新（如有必要）

## 测试

修改并运行了已有测试

## 附加信息

无
