### PR TITLE
Feat/mtp executor cancel

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -245,12 +245,15 @@ v0.5.0 的意义：把“对话事实”和“记忆事实”从运行时缓存�
 - MTP READ 从简单读取 payload 升级为读取版本历史、provenance、artifact 来源。
 - MTP RUN 从执行 `payload.content` 升级为从记忆原子编译 executable asset。
 - 引入权限快照、构建过程、运行前检查和执行结果 artifact。
+- **隔离沙箱执行环境**：引入 Docker 或等效容器隔离，替换当前 dev-grade `subprocess` 占位实现；沙箱具备进程级隔离、资源限制与可审计的执行结果。
+- **MTP RUN 真取消**：基于隔离沙箱的 `kill()` 能力，实现 `cancel_event` 触发时对正在执行的 RUN 指令的主动中断（而非依赖 timeout 自然退出）；syscall handler 升级为 async，与 v0.5.1 已落地的 checkpoint 取消语义完整衔接。
 
 依赖：
 
 - MemoryCompiler IR 继续推进。
 - v0.5.0 的 artifact/provenance。
 - v0.4.0 的 cancel 与 runtime event。
+- v0.5.1 的 `CANCELLED` 状态与 MTP executor checkpoint 取消基础。
 
 ### v0.8.0 候选: Alice Phase 3 顶层编排
 

--- a/docs/mod/V0.5.1InfraCleanupPlan.md
+++ b/docs/mod/V0.5.1InfraCleanupPlan.md
@@ -144,7 +144,7 @@ AgentRun.cancel()
 
 - `alice/runtime/koakuma.py`（或当前等效文件）：`_run_loop` 在每轮迭代前检查
 - `MTP executor`：各 verb 耗时操作前加取消检查点
-- 取消时以 `SUSPEND`（待 resume）或直接 `CANCELLED` 状态退出，视当前 frame 语义而定
+- 取消时以 `CANCELLED` 状态退出
 
 ### 3.4 验收
 

--- a/src/hivememory/agent_runtime/loop_executor.py
+++ b/src/hivememory/agent_runtime/loop_executor.py
@@ -162,14 +162,18 @@ class AgentLoopExecutor:
                 logger.info("Generation cancelled before MTP execution")
                 break
 
-            # TODO: Propagate cancel_event into the MTP executor itself so long-running
-            # tool/syscall execution can stop while it is in progress.
+            if cancel_event is not None and hasattr(self._mtp_executor, "set_cancel_event"):
+                self._mtp_executor.set_cancel_event(cancel_event)
             mtp_result = await self._mtp_executor.intercept_and_execute(
                 result.text,
                 context=mtp_context,
             )
             if cancel_event is not None and cancel_event.is_set():
                 logger.info("Generation cancelled after MTP execution")
+                break
+
+            if mtp_result is not None and mtp_result.response_status == "cancelled":
+                logger.info("MTP execution cancelled")
                 break
 
             if mtp_result is not None and mtp_result.command:
@@ -289,6 +293,8 @@ class AgentLoopExecutor:
             ))
             p.sequence += 1
 
+        if cancel_event is not None and cancel_event.is_set():
+            return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
         return FrameExecutionResult(status=FrameExecutionStatus.COMPLETED)
 
     async def execute_frame_stream(

--- a/src/hivememory/agent_runtime/models.py
+++ b/src/hivememory/agent_runtime/models.py
@@ -120,6 +120,7 @@ class FrameExecutionStatus(str, Enum):
 
     COMPLETED = "completed"   # 自然收敛
     SUSPENDED = "suspended"   # 命中 CALL，等待编排派生子 agent
+    CANCELLED = "cancelled"   # 收到取消信号，提前退出
 
 
 @dataclass

--- a/src/hivememory/agent_runtime/mtp/mtp_executor.py
+++ b/src/hivememory/agent_runtime/mtp/mtp_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 from typing import Optional, TYPE_CHECKING
 
@@ -27,6 +28,9 @@ class KoakumaMTPExecutor(MTPExecutor):
 
     def __init__(self, koakuma: "KoakumaRuntime") -> None:
         self._koakuma = koakuma
+
+    def set_cancel_event(self, cancel_event: Optional[asyncio.Event]) -> None:
+        self._koakuma.cancel_event = cancel_event
 
     async def intercept_and_execute(
         self,

--- a/src/hivememory/agent_runtime/mtp/runtime.py
+++ b/src/hivememory/agent_runtime/mtp/runtime.py
@@ -24,6 +24,7 @@
 版本: 1.0
 """
 
+import asyncio
 import time
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
@@ -155,6 +156,8 @@ class KoakumaRuntime:
         )
 
         self._compiler = MemoryCompiler()
+
+        self.cancel_event: Optional[asyncio.Event] = None
 
         logger.info("KoakumaRuntime (小恶魔 MTP 运行时) 初始化完成")
 
@@ -302,6 +305,16 @@ class KoakumaRuntime:
         if last_open == -1:
             return None
 
+        if self.cancel_event is not None and self.cancel_event.is_set():
+            return MTPExecutionResult(
+                command=None,
+                response_status=MTPResponseStatus.CANCELLED.value,
+                response_content="",
+                formatted_response="",
+                success=False,
+                execution_time_ms=0.0,
+            )
+
         # 提取从 ⟪ 开始的文本片段
         mtp_fragment = assistant_text[last_open:]
 
@@ -355,6 +368,8 @@ class KoakumaRuntime:
             )
 
         try:
+            if self.cancel_event is not None and self.cancel_event.is_set():
+                return MTPResponse(status=MTPResponseStatus.CANCELLED, content="")
             # 权限沙箱：校验 MTP 动词权限 (Phase 1 多智能体)
             self._check_verb_permission(command.verb.value, context=context)
             return await handler(command, context)

--- a/src/hivememory/core/mtp/models.py
+++ b/src/hivememory/core/mtp/models.py
@@ -57,6 +57,7 @@ class MTPResponseStatus(str, Enum):
     ACK = "ack"
     WARNING = "warning"
     SUSPEND = "suspend"
+    CANCELLED = "cancelled"
 
 
 class MTPTarget(BaseModel):

--- a/tests/unit/agent_runtime/mtp/test_call_handler.py
+++ b/tests/unit/agent_runtime/mtp/test_call_handler.py
@@ -60,6 +60,8 @@ class TestKoakumaHandleCall:
             runtime_scope=RuntimeScope(depth=depth),
         )
 
+        koakuma.cancel_event = None  # instance var not in MagicMock spec
+
         # 绑定真实方法
         import types
         koakuma._handle_call = types.MethodType(


### PR DESCRIPTION
## 描述

将取消事件传入Koakuma，使得在内部解析并执行MTP指令时同样能够响应取消事件。MTP RUN取消延后至沙箱环境建立后

## 类型

- [ ] Bug 修复 (fix)
- [x] 新功能 (feat)
- [ ] 代码重构 (refactor)
- [ ] 文档更新 (docs)
- [ ] 代码风格更新 (style)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 构建/CI 更新 (build/ci)
- [ ] 其他变更 (chore)

## 相关 Issue

无

## 检查清单

- [x] 我已经阅读了项目的贡献指南
- [x] 我已经自我审查了代码，并确保其符合项目的代码风格与规范
- [x] 代码通过了 lint 检查
- [x] 添加了必要的测试用例并全部通过
- [x] 文档已更新（如有必要）

## 测试

添加并运行了已有测试

## 附加信息

无
