### PR TITLE
feat:恢复旧gateway LLM Analyzer行为

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ Desktop.ini
 .claude
 .trae
 .agents
+
+# project files
+.hivememory

--- a/docs/mod/V0.6.0UserQueryAnalysisGen1TechDebt.md
+++ b/docs/mod/V0.6.0UserQueryAnalysisGen1TechDebt.md
@@ -1,0 +1,107 @@
+# User Query Analysis 第一代实现：技术债说明与第二代规划
+
+**文档状态**: Active
+**适用范围**: `gateway/analysis/`、`engines/gateway/query_understanding.py`、`gateway/workflow/topology.py`
+**前置文档**: [`V0.6.0GatewaySystemDesign.md`](./V0.6.0GatewaySystemDesign.md)（§6.8、§7、§8）
+
+---
+
+## 1. 第一代实现概述
+
+第一代 `LLMUserQueryAnalysisResolver` 恢复了旧单次 LLM Router 中除话题路由外的全部分析能力，同时控制入口延迟与 token 成本。结构为三层：
+
+```text
+LLMUserQueryAnalysisResolver
+  ├─ Tier 0: 本地规则（~0ms）
+  │    ├─ 显式记忆指令模式（"记住…" / "以后…" / "remember…"）→ intent=WRITE + signal=WRITE
+  │    └─ 重复输入检测（与 routed topic 上一轮用户输入规范化比对）→ signal=SKIP
+  ├─ Tier 1: 单次共享 LLM 调用（QueryUnderstandingEngine）
+  │    输出: intent_type / rewritten_query / search_keywords /
+  │          memory_write_signal / sub_intents(仅 COMPOSITE) / reason
+  └─ Tier 2: 纯函数派生（~0ms）
+       └─ RetrievalPlan：CHAT/WRITE → SKIP；无关键词 → DENSE；否则 HYBRID
+```
+
+关键决策：
+
+- **一次 LLM 调用覆盖四个候选能力边界**（QueryUnderstanding / IntentClassifier / MemoryValueJudge / IntentDecomposer）。这些能力读取完全相同的输入（raw_message + routed_topic_data），共享推理过程，拆开只会线性放大延迟与 token 成本。
+- **意图分解不独立实现**：仅以 `sub_intents` 可选字段存在于共享调用输出中，作为 Resolver 私有中间结果，不写入 execution state 或公共协议。
+- **检索策略不用 LLM**：是对结构化信号的聚合决策，规则派生足够准确。
+- **能力失败局部降级**：Engine 对 `rewritten_query` 严格校验（缺失即失败），其余字段宽容解析（非法 intent → RAG，非法 signal → UNKNOWN）；整体失败转换为 `RecoverableGatewayError`，落入 Step 级保守 fallback（UNKNOWN + HYBRID，已按设计文档 §6.8 修正）。
+
+## 2. 技术债清单
+
+### 2.1 MemoryValueJudge 需要重新设计（已确认）
+
+**现状问题**：记忆价值判断的输入侧筛选价值已经大幅缩水
+
+- 明显不值得存的输入（寒暄、短确认、无意义短文本）已被 Entry Interception 的 `CHAT_PATTERNS` 拦截，走 Simple Chat 旁路直接 `SKIP`，根本不进入分析层。
+- 到达分析层的输入大多是实质提问或陈述，初判结果大概率是 `WRITE` 或 `UNKNOWN`，字段区分度低。
+- 当前判断发生在**用户输入到达时**（turn 开始前），此时无法知道本轮交互的实际产出质量。一个看似有价值的问题可能得到无用回答，一个看似简单的确认可能伴随重要状态变更。
+
+**重设计方向（第二代）**：
+
+1. **判断时机后移**：从"输入级预判"转向"轮次级结果评估"。在 Patchouli finalize 阶段，基于完整的 `InteractionPayload`（用户输入 + assistant 回复 + MTP traces）评估本轮交互是否值得物化。判断材料更充分，误杀率更低。
+2. **Gateway 侧信号弱化或重定义**：`memory_write_signal` 保留为低成本前置过滤（规则可判的显式 WRITE / 明显重复 SKIP），LLM 初判字段可下线；终判权移交 finalize 侧的 Memory Value 评估能力（可以是感知层现有能力的扩展）。
+3. **三态语义重新审视**：`UNKNOWN` 当前等价于"保留"，重设计后应明确"无 Gateway 前置意见"与"无法判断"的边界，避免字段语义随实现漂移。
+4. **评估指标先行**：重设计前需要统计当前信号在物化过滤中的实际拦截率与误杀率（见 §3.2），用数据决定字段去留，而不是凭直觉保留兼容性。
+
+### 2.2 共享调用的"博而不精"风险
+
+单次调用同时完成四项任务，任一任务的 prompt 篇幅都被压缩。旧 Router 正是因此退化。当前未验证：
+
+- rewrite 是否照抄原文（未做陈述句转换）；
+- keywords 提取质量（数量、是否专有名词）；
+- COMPOSITE 识别率与 `sub_intents` 可用性。
+
+第一代以恢复闭环为优先，质量验证留给第二代（§3.2 的观测指标）。
+
+### 2.3 `sub_intents` 无消费者
+
+分解结果只进 Resolver 私有中间值，当前唯一作用是辅助 LLM 自身组织 rewrite。若长期无下游消费者（多 decision 输出、Alice 任务图），该字段应从 prompt 中移除以压缩 token。
+
+### 2.4 RetrievalPlan 部分字段无下游消费者
+
+`dense_weight` / `sparse_weight` / `DENSE` 与 `HYBRID` 的区分当前不被 `RetrievalRequest` 消费（Patchouli 只读 SKIP/top_k）。派生逻辑已就位，但需要 Patchouli 检索层支持权重后才有实际意义。
+
+### 2.5 规则列表的维护成本
+
+`_WRITE_INTENT_PATTERNS` 与 `CHAT_PATTERNS` 同为硬编码正则，存在中英文覆盖不全、与 LLM 判断冲突时仲裁规则简单（规则优先）的问题。第二代应考虑将高置信模式迁移为 i18n 资源或配置。
+
+### 2.6 配置暂未完全私有化
+
+`enabled` / `model_override` / `context_block_limit` / `context_text_limit` 暂挂在 `UserQueryAnalysisConfig` 顶层配置中。按设计文档 §11，Resolver 契约稳定后应将 Engine 级配置下沉为 Resolver 私有配置。
+
+## 3. 第二代规划
+
+### 3.1 前提：契约验证
+
+按设计文档 §8.2，拆分任何候选 Engine 前必须回答并验证：Required inputs / Optional inputs / Outputs / Consumer / Latency-cost / Failure policy / Ordering / Concurrency / Side effects。不允许先按设想建立 Engine wrapper 和固定调用顺序。
+
+### 3.2 观测指标先行
+
+利用已接入的 `GatewayAnalysisCapabilityCompleted` 事件与 golden scenarios，先建立各能力的质量度量：
+
+| 指标 | 目的 |
+| --- | --- |
+| rewrite 与原文的编辑距离/重复率 | 验证陈述句改写是否生效 |
+| keywords 数量分布与稀疏检索命中率 | 验证关键词提取质量 |
+| memory_write_signal 分布与物化过滤拦截率、误杀率 | 为 MemoryValueJudge 重设计提供去留依据 |
+| COMPOSITE 占比与 sub_intents 非空率 | 决定意图分解是否值得独立 |
+
+### 3.3 候选演进路径
+
+1. **MemoryValueJudge 重设计**（优先级最高，见 §2.1）：判断时机后移至 finalize 轮次级评估，Gateway 侧只保留规则前置过滤。
+2. **按数据决定是否拆分共享调用**：仅当某能力质量指标明显退化时拆为独立 Engine；拆分后各项能力读取同一不可变 context，无已验证串行依赖，应并发执行（`asyncio.gather`），延迟不按调用数叠加。
+3. **Patchouli 检索层消费完整 RetrievalPlan**：支持 mode/weight 后，DENSE/HYBRID 派生才产生实际效果。
+4. **规则资源配置化**：将 WRITE/CHAT 模式迁移为可维护的资源文件，并定义规则与 LLM 判断冲突时的仲裁策略。
+5. **配置下沉**：Resolver 契约稳定后，Engine 模型/Prompt/timeout/并发配置从顶层配置收回 Resolver 私有。
+
+### 3.4 不变量
+
+无论内部如何演进，以下契约不得改变（设计文档 §8.1）：
+
+- `UserQueryAnalysisContext` 输入边界与 `UserQueryAnalysisResult` 完整只读输出边界；
+- User Query Analysis 在顶层 Workflow 中只占一个 Step、只 apply 一次；
+- Resolver 不修改 topic route，不执行检索、记忆写入或 planning；
+- Step 级 fallback 一次性补齐 finalize 所需的完整保守结果。

--- a/src/hivememory/engines/gateway/__init__.py
+++ b/src/hivememory/engines/gateway/__init__.py
@@ -9,7 +9,12 @@ from hivememory.engines.gateway.interfaces import BaseInterceptor
 from hivememory.engines.gateway.models import (
     GatewayIntent,
     InterceptorResult,
+    QueryUnderstandingResult,
     TopicRoutingResult,
+)
+from hivememory.engines.gateway.query_understanding import (
+    QueryUnderstandingEngine,
+    QueryUnderstandingError,
 )
 from hivememory.engines.gateway.topic_router import (
     TopicRouterEngine,
@@ -21,6 +26,9 @@ __all__ = [
     "GatewayIntent",
     "InterceptorResult",
     "NoOpInterceptor",
+    "QueryUnderstandingEngine",
+    "QueryUnderstandingError",
+    "QueryUnderstandingResult",
     "RuleInterceptor",
     "TopicRouterEngine",
     "TopicRouterError",

--- a/src/hivememory/engines/gateway/models.py
+++ b/src/hivememory/engines/gateway/models.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from hivememory.core.protocol.gateway import IntentType, MemoryWriteSignal
 from hivememory.gateway.commands.models import CommandParseResult
 
 
@@ -42,4 +43,22 @@ class InterceptorResult(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
-__all__ = ["GatewayIntent", "InterceptorResult", "TopicRoutingResult"]
+class QueryUnderstandingResult(BaseModel):
+    """共享查询分析调用的原始输出，属于 Resolver 私有中间结果。"""
+
+    intent_type: IntentType = IntentType.RAG
+    rewritten_query: str
+    search_keywords: tuple[str, ...] = ()
+    memory_write_signal: MemoryWriteSignal = MemoryWriteSignal.UNKNOWN
+    sub_intents: tuple[str, ...] = ()
+    reason: str = ""
+
+    model_config = ConfigDict(frozen=True)
+
+
+__all__ = [
+    "GatewayIntent",
+    "InterceptorResult",
+    "QueryUnderstandingResult",
+    "TopicRoutingResult",
+]

--- a/src/hivememory/engines/gateway/query_understanding.py
+++ b/src/hivememory/engines/gateway/query_understanding.py
@@ -1,0 +1,135 @@
+"""第一代共享查询分析 Engine 原语。
+
+一次 LLM 调用同时完成意图识别、指代消解与查询重写、检索关键词提取、
+记忆价值初判，并在复合意图时给出可选的子意图列表。
+
+技术债说明：该 Engine 当前覆盖了 QueryUnderstanding / IntentClassifier /
+MemoryValueJudge / IntentDecomposer 四个候选能力边界，属于第一代
+Resolver 的私有实现细节，后续按观测数据决定是否拆分。
+"""
+
+from __future__ import annotations
+
+from hivememory.core.models import TopicData
+from hivememory.engines.gateway.models import QueryUnderstandingResult
+from hivememory.core.protocol.gateway import IntentType, MemoryWriteSignal
+from hivememory.i18n import resolve_language
+from hivememory.infrastructure.llm.base import BaseLLMService
+from hivememory.prompts.gateway import get_query_understanding_system_prompt
+from hivememory.system.config import UserQueryAnalysisConfig
+from hivememory.utils.json_parser import parse_llm_json
+
+
+class QueryUnderstandingError(RuntimeError):
+    """Query Understanding 的预期能力或解析失败。"""
+
+
+class QueryUnderstandingEngine:
+    """基于单次 LLM 调用的共享查询分析能力。"""
+
+    def __init__(
+        self,
+        *,
+        config: UserQueryAnalysisConfig,
+        llm_service: BaseLLMService | None,
+    ) -> None:
+        self._config = config
+        self._llm_service = llm_service
+        self._language = resolve_language().value
+
+    async def analyze(
+        self,
+        message: str,
+        *,
+        topic_data: TopicData | None = None,
+    ) -> QueryUnderstandingResult:
+        """完成一次共享查询分析，不执行检索、写入或话题选择。"""
+
+        if self._llm_service is None:
+            raise QueryUnderstandingError("Query Understanding 未配置 LLM 服务")
+
+        prompt = get_query_understanding_system_prompt(
+            language=self._language,
+            topic_context=self._render_topic_context(topic_data),
+        )
+        kwargs = {}
+        if self._config.model_override:
+            kwargs["model"] = self._config.model_override
+        try:
+            content = await self._llm_service.acomplete_json(
+                messages=[
+                    {"role": "system", "content": prompt},
+                    {"role": "user", "content": message},
+                ],
+                **kwargs,
+            )
+            payload = parse_llm_json(content)
+            return self._validate_result(payload)
+        except QueryUnderstandingError:
+            raise
+        except Exception as exc:
+            raise QueryUnderstandingError(f"Query Understanding 调用失败: {exc}") from exc
+
+    def _render_topic_context(self, topic_data: TopicData | None) -> str:
+        if topic_data is None:
+            return ""
+        lines: list[str] = [f"{topic_data.topic_title}"]
+        if topic_data.topic_summary:
+            lines.append(topic_data.topic_summary)
+        if topic_data.state_summary:
+            lines.append(topic_data.state_summary)
+        text_limit = self._config.context_text_limit
+        for block in topic_data.recent_blocks(self._config.context_block_limit):
+            user_text = block.user_query[:text_limit]
+            assistant_text = block.assistant_final_text[:text_limit]
+            if user_text:
+                lines.append(f"user: {user_text}")
+            if assistant_text:
+                lines.append(f"assistant: {assistant_text}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _validate_result(payload: object) -> QueryUnderstandingResult:
+        if not isinstance(payload, dict):
+            raise QueryUnderstandingError("Query Understanding 未返回 JSON object")
+        rewritten_query = payload.get("rewritten_query")
+        if not isinstance(rewritten_query, str) or not rewritten_query.strip():
+            raise QueryUnderstandingError("Query Understanding 缺少 rewritten_query")
+
+        intent_raw = payload.get("intent_type")
+        try:
+            intent_type = IntentType(str(intent_raw))
+        except ValueError:
+            intent_type = IntentType.RAG
+
+        signal_raw = payload.get("memory_write_signal")
+        try:
+            memory_write_signal = MemoryWriteSignal(str(signal_raw))
+        except ValueError:
+            memory_write_signal = MemoryWriteSignal.UNKNOWN
+
+        keywords_raw = payload.get("search_keywords")
+        search_keywords = (
+            tuple(str(kw) for kw in keywords_raw if str(kw).strip())
+            if isinstance(keywords_raw, list)
+            else ()
+        )
+
+        sub_intents_raw = payload.get("sub_intents")
+        sub_intents = (
+            tuple(str(item) for item in sub_intents_raw if str(item).strip())
+            if isinstance(sub_intents_raw, list)
+            else ()
+        )
+
+        return QueryUnderstandingResult(
+            intent_type=intent_type,
+            rewritten_query=rewritten_query,
+            search_keywords=search_keywords,
+            memory_write_signal=memory_write_signal,
+            sub_intents=sub_intents,
+            reason=str(payload.get("reason") or ""),
+        )
+
+
+__all__ = ["QueryUnderstandingEngine", "QueryUnderstandingError"]

--- a/src/hivememory/gateway/analysis/__init__.py
+++ b/src/hivememory/gateway/analysis/__init__.py
@@ -5,10 +5,14 @@ from hivememory.gateway.analysis.models import (
     UserQueryAnalysisResolver,
     UserQueryAnalysisResult,
 )
-from hivememory.gateway.analysis.resolver import FallbackUserQueryAnalysisResolver
+from hivememory.gateway.analysis.resolver import (
+    FallbackUserQueryAnalysisResolver,
+    LLMUserQueryAnalysisResolver,
+)
 
 __all__ = [
     "FallbackUserQueryAnalysisResolver",
+    "LLMUserQueryAnalysisResolver",
     "UserQueryAnalysisContext",
     "UserQueryAnalysisResolver",
     "UserQueryAnalysisResult",

--- a/src/hivememory/gateway/analysis/resolver.py
+++ b/src/hivememory/gateway/analysis/resolver.py
@@ -1,6 +1,14 @@
-"""User Query Analysis 的保守解析器实现。"""
+"""User Query Analysis 的 Resolver 实现。
+
+- `FallbackUserQueryAnalysisResolver`：不调用 Engine，生成稳定保守结果。
+- `LLMUserQueryAnalysisResolver`：第一代实现，本地规则前置 + 单次共享
+  LLM 调用（意图/重写/关键词/记忆价值初判）+ 纯函数派生检索计划。
+"""
 
 from __future__ import annotations
+
+import re
+from time import perf_counter
 
 from hivememory.core.protocol.gateway import (
     IntentType,
@@ -8,11 +16,18 @@ from hivememory.core.protocol.gateway import (
     RetrievalMode,
     RetrievalPlan,
 )
+from hivememory.engines.gateway.query_understanding import (
+    QueryUnderstandingEngine,
+    QueryUnderstandingError,
+)
 from hivememory.gateway.analysis.models import (
     UserQueryAnalysisContext,
     UserQueryAnalysisResult,
 )
+from hivememory.gateway.errors import RecoverableGatewayError
 from hivememory.system.config import UserQueryAnalysisConfig
+from hivememory.system.contracts.runtime_events import RuntimeEvent, RuntimeEventType
+from hivememory.system.runtime.events import NullRuntimeEventSink, RuntimeEventSink
 
 
 class FallbackUserQueryAnalysisResolver:
@@ -39,4 +54,145 @@ class FallbackUserQueryAnalysisResolver:
         )
 
 
-__all__ = ["FallbackUserQueryAnalysisResolver"]
+class LLMUserQueryAnalysisResolver:
+    """第一代 Resolver：规则前置 + 单次共享 LLM 调用 + 纯函数派生。
+
+    技术债说明：意图识别、query rewrite、记忆价值初判与意图分解当前共享
+    一次 LLM 调用（QueryUnderstandingEngine）；记忆价值判断未来需要重新
+    设计，详见第一代技术债文档。
+    """
+
+    _WRITE_INTENT_PATTERNS: tuple[str, ...] = (
+        r"^(请|帮我|帮忙)?记住",
+        r"^以后(都|请|帮我|要)?",
+        r"^从现在开始",
+        r"^remember\b",
+        r"^from now on\b",
+    )
+
+    def __init__(
+        self,
+        *,
+        config: UserQueryAnalysisConfig,
+        engine: QueryUnderstandingEngine,
+        runtime_events: RuntimeEventSink | None = None,
+    ) -> None:
+        self._config = config
+        self._engine = engine
+        self._runtime_events = runtime_events or NullRuntimeEventSink()
+        self._write_patterns = [
+            re.compile(pattern, re.IGNORECASE)
+            for pattern in self._WRITE_INTENT_PATTERNS
+        ]
+
+    async def resolve(
+        self,
+        context: UserQueryAnalysisContext,
+    ) -> UserQueryAnalysisResult:
+        """完成一次完整查询分析；能力失败转换为 RecoverableGatewayError。"""
+
+        rule_intent, rule_signal = self._apply_rules(context)
+
+        started_at = perf_counter()
+        try:
+            analysis = await self._engine.analyze(
+                context.raw_message,
+                topic_data=context.routed_topic_data,
+            )
+        except QueryUnderstandingError as exc:
+            self._emit_capability(started_at, error=exc)
+            raise RecoverableGatewayError(str(exc)) from exc
+        self._emit_capability(started_at, error=None)
+
+        intent_type = rule_intent or analysis.intent_type
+        memory_write_signal = rule_signal or analysis.memory_write_signal
+        retrieval_plan = self._derive_retrieval_plan(
+            intent_type=intent_type,
+            search_keywords=analysis.search_keywords,
+        )
+        return UserQueryAnalysisResult(
+            intent_type=intent_type,
+            rewritten_query=analysis.rewritten_query,
+            search_keywords=analysis.search_keywords,
+            memory_write_signal=memory_write_signal,
+            retrieval_plan=retrieval_plan,
+        )
+
+    def _apply_rules(
+        self,
+        context: UserQueryAnalysisContext,
+    ) -> tuple[IntentType | None, MemoryWriteSignal | None]:
+        """零成本前置规则：显式记忆指令与重复输入检测。"""
+
+        text = context.raw_message.strip()
+        if any(pattern.search(text) for pattern in self._write_patterns):
+            return IntentType.WRITE, MemoryWriteSignal.WRITE
+        if self._is_repeated_input(context):
+            return None, MemoryWriteSignal.SKIP
+        return None, None
+
+    def _is_repeated_input(self, context: UserQueryAnalysisContext) -> bool:
+        topic_data = context.routed_topic_data
+        if topic_data is None:
+            return False
+        recent = topic_data.recent_blocks(1)
+        if not recent:
+            return False
+        return self._normalize(recent[0].user_query) == self._normalize(
+            context.raw_message
+        )
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return "".join(text.split()).lower()
+
+    def _derive_retrieval_plan(
+        self,
+        *,
+        intent_type: IntentType,
+        search_keywords: tuple[str, ...],
+    ) -> RetrievalPlan:
+        """检索策略是纯派生：由意图与关键词决定，不单独调用模型。"""
+
+        if intent_type in (IntentType.CHAT, IntentType.WRITE):
+            return RetrievalPlan(mode=RetrievalMode.SKIP, top_k=0)
+        if not search_keywords:
+            return RetrievalPlan(
+                mode=RetrievalMode.DENSE,
+                top_k=self._config.default_top_k,
+            )
+        return RetrievalPlan(
+            mode=RetrievalMode.HYBRID,
+            top_k=self._config.default_top_k,
+        )
+
+    def _emit_capability(
+        self,
+        started_at: float,
+        *,
+        error: QueryUnderstandingError | None,
+    ) -> None:
+        """Resolver 内部能力调用的观测事件，失败不得影响业务结果。"""
+
+        try:
+            self._runtime_events.emit(
+                RuntimeEvent(
+                    event_type=RuntimeEventType.GATEWAY_ANALYSIS_CAPABILITY_COMPLETED,
+                    subsystem="gateway",
+                    component="user_query_analysis",
+                    severity="warning" if error is not None else "info",
+                    data={
+                        "capability_id": "query_understanding",
+                        "duration_ms": (perf_counter() - started_at) * 1000,
+                        "error": str(error) if error is not None else None,
+                    },
+                )
+            )
+        except Exception:
+            return
+
+
+__all__ = [
+    "FallbackUserQueryAnalysisResolver",
+    "LLMUserQueryAnalysisResolver",
+]

--- a/src/hivememory/gateway/runtime/core.py
+++ b/src/hivememory/gateway/runtime/core.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from typing import Any
 
 from hivememory.engines.gateway.interceptors import create_interceptor
+from hivememory.engines.gateway.query_understanding import QueryUnderstandingEngine
 from hivememory.engines.gateway.topic_router import TopicRouterEngine
 from hivememory.gateway.analysis import (
     FallbackUserQueryAnalysisResolver,
+    LLMUserQueryAnalysisResolver,
     UserQueryAnalysisResolver,
 )
 from hivememory.gateway.commands import (
@@ -67,9 +69,19 @@ class GatewayRuntime:
                 llm_service=llm_service,
             )
         if analysis_resolver is None:
-            analysis_resolver = FallbackUserQueryAnalysisResolver(
-                config.user_query_analysis
-            )
+            if llm_service is not None and config.user_query_analysis.enabled:
+                analysis_resolver = LLMUserQueryAnalysisResolver(
+                    config=config.user_query_analysis,
+                    engine=QueryUnderstandingEngine(
+                        config=config.user_query_analysis,
+                        llm_service=llm_service,
+                    ),
+                    runtime_events=self._runtime_events,
+                )
+            else:
+                analysis_resolver = FallbackUserQueryAnalysisResolver(
+                    config.user_query_analysis
+                )
 
         registry = create_builtin_command_registry(config.commands.builtin)
         interceptor = create_interceptor(config.interceptor, registry)

--- a/src/hivememory/gateway/workflow/topology.py
+++ b/src/hivememory/gateway/workflow/topology.py
@@ -320,7 +320,7 @@ def _conservative_analysis_result(
         intent_type=IntentType.RAG,
         rewritten_query=raw_message,
         search_keywords=(),
-        memory_write_signal=MemoryWriteSignal.WRITE,
+        memory_write_signal=MemoryWriteSignal.UNKNOWN,
         retrieval_plan=RetrievalPlan(
             mode=RetrievalMode.HYBRID,
             top_k=config.default_top_k,

--- a/src/hivememory/i18n/prompts.py
+++ b/src/hivememory/i18n/prompts.py
@@ -185,7 +185,39 @@ _GATEWAY_PROMPT_TEXT_ZH = {
 
 若输入属于某个活跃话题，target_topic 必须使用列表中的 topic_id；否则使用 NEW_TOPIC，并给出简短的新话题标题和一句话摘要。
 只返回 JSON object，字段固定为 target_topic、new_topic_title、new_topic_summary、reason。""",
+    "query_understanding_prompt": """你是 HiveMemory 的查询分析器。用户输入已完成话题路由，你的任务是结合所属话题的上下文，完成意图识别、查询重写、检索关键词提取和记忆价值初判。你不负责选择话题。
+
+【所属话题上下文】
+{topic_context}
+
+【处理规则】
+1. 意图识别 intent_type：
+   - RAG：需要检索历史记忆或上下文才能回答的提问或请求。
+   - WRITE：用户主动陈述偏好、禁忌、事实、经验等需要长期记住的信息，通常不需要检索。
+   - COMPOSITE：同一输入同时包含提问与需要记忆的陈述等多个意图。
+
+2. 检索优化重写 rewritten_query [关键]:
+   - 结合话题上下文消除指代（它/这个/那个/之前说的）。
+   - 禁止照抄用户的口语化提问（去掉"如何"、"帮我"、"怎么"等疑问/祈使词）。
+   - 必须重写为"陈述句形态的知识点描述"或"假设性文档标题"，提取核心意图，补充潜在的上下文语境与相关领域术语。
+   - 示例：
+     * 用户："如何做一份好吃的红烧羊肉？" -> "红烧羊肉的完整食谱、做法步骤及烹饪注意事项"
+     * 用户："那个报错怎么修？" (话题上下文: Docker 内存溢出) -> "Docker Out of Memory (OOM) 内存溢出报错的排查原因与修复方案"
+     * 用户："把它部署上去" (话题上下文：基于 Vue 实现前端网站) -> "前端 Vue 网站项目的服务器部署指令与执行流程"
+
+3. 稀疏检索 search_keywords：提取 3-5 个专有名词、动词或核心实体，用于精确匹配。
+
+4. 记忆价值初判 memory_write_signal：
+   - WRITE：用户明确表达的偏好、硬性禁忌、重要事实、可复用的技术方案。
+   - SKIP：纯确认或附和、与上文重复的提问、无信息量的情绪表达。
+   - UNKNOWN：无法确定时使用（保守，交给下游决定）。
+
+5. 复合意图分解 sub_intents：仅当 intent_type 为 COMPOSITE 时，列出 2-4 个子意图的一句话简述；否则返回空数组。
+
+请严格返回一个 JSON object，不要输出 Markdown、代码块或解释文字。JSON 字段必须包含：
+intent_type、rewritten_query、search_keywords、memory_write_signal、sub_intents、reason。""",
     "active_topics_empty": "无",
+    "topic_context_empty": "无（新话题，暂无历史上下文）",
 }
 
 _GATEWAY_PROMPT_TEXT_EN = {
@@ -196,7 +228,39 @@ Active topics:
 
 If the input belongs to an active topic, target_topic must be one of the listed topic IDs. Otherwise use NEW_TOPIC and provide a concise title and one-sentence summary.
 Return only one JSON object with target_topic, new_topic_title, new_topic_summary, and reason.""",
+    "query_understanding_prompt": """You are HiveMemory's query analyzer. The user input has already been routed to a topic. Using the routed topic's context, perform intent classification, query rewriting, retrieval keyword extraction, and an initial memory-value judgment. You do not choose the topic.
+
+[Routed Topic Context]
+{topic_context}
+
+[Rules]
+1. Intent classification intent_type:
+   - RAG: a question or request that needs historical memory or context retrieval to answer.
+   - WRITE: the user proactively states preferences, hard constraints, facts, or experience worth remembering long-term; retrieval is usually unnecessary.
+   - COMPOSITE: the input combines multiple intents, e.g. both a question and a statement worth remembering.
+
+2. Retrieval-optimized rewrite rewritten_query [CRITICAL]:
+   - Resolve coreferences (it/this/that/the previous one) using the topic context.
+   - FORBIDDEN to verbatim copy the user's colloquial question (remove interrogative/imperative words like "how to", "help me", "how do I").
+   - MUST rewrite into a "declarative knowledge description" or a "hypothetical document title", extracting the core intent and supplementing potential context and related domain terminology.
+   - Examples:
+     * User: "How to make delicious braised mutton?" -> "Complete recipe, preparation steps, and cooking precautions for braised mutton"
+     * User: "How to fix that error?" (Context: Docker Out of Memory) -> "Troubleshooting causes and fixing solutions for Docker Out of Memory (OOM) error"
+     * User: "Deploy it" (Context: Frontend website based on Vue) -> "Server deployment instructions and execution workflow for frontend Vue website project"
+
+3. Sparse retrieval search_keywords: extract 3-5 proper nouns, verbs, or core entities for exact matching.
+
+4. Initial memory-value judgment memory_write_signal:
+   - WRITE: explicitly stated preferences, hard constraints, important facts, reusable technical solutions.
+   - SKIP: pure confirmations or acknowledgments, questions repeated from above, emotion-only expressions with no information.
+   - UNKNOWN: use when uncertain (conservative; leave the decision downstream).
+
+5. Composite decomposition sub_intents: only when intent_type is COMPOSITE, list 2-4 one-sentence sub-intent summaries; otherwise return an empty array.
+
+Return exactly one JSON object. Do not output markdown, code fences, or prose. The JSON fields must include:
+intent_type, rewritten_query, search_keywords, memory_write_signal, sub_intents, reason.""",
     "active_topics_empty": "None",
+    "topic_context_empty": "None (new topic, no history yet)",
 }
 
 _RELAY_PROMPT_TEXT_ZH = {

--- a/src/hivememory/prompts/gateway.py
+++ b/src/hivememory/prompts/gateway.py
@@ -1,4 +1,4 @@
-"""Gateway Topic Router 提示词。"""
+"""Gateway Topic Router 与查询分析提示词。"""
 
 from hivememory.i18n import get_gateway_prompt_text
 
@@ -14,6 +14,18 @@ def get_topic_router_system_prompt(
     return template.replace("{active_topics_menu}", menu)
 
 
+def get_query_understanding_system_prompt(
+    language: str = "zh",
+    topic_context: str | None = None,
+) -> str:
+    """获取路由后共享查询分析（意图/重写/关键词/记忆价值）的 prompt。"""
+
+    template = get_gateway_prompt_text("query_understanding_prompt", language)
+    context = topic_context or get_gateway_prompt_text("topic_context_empty", language)
+    return template.replace("{topic_context}", context)
+
+
 __all__ = [
+    "get_query_understanding_system_prompt",
     "get_topic_router_system_prompt",
 ]

--- a/src/hivememory/system/config/gateway.py
+++ b/src/hivememory/system/config/gateway.py
@@ -57,10 +57,14 @@ class TopicRouterConfig(BaseModel):
 
 
 class UserQueryAnalysisConfig(BaseModel):
-    """User Query Analysis 整体 deadline 与保守默认值。"""
+    """User Query Analysis 整体 deadline、保守默认值与第一代 Resolver 私有配置。"""
 
+    enabled: bool = True
     overall_timeout_ms: int = Field(default=5000, ge=1)
     default_top_k: int = Field(default=5, ge=0)
+    model_override: str | None = None
+    context_block_limit: int = Field(default=3, ge=0)
+    context_text_limit: int = Field(default=200, ge=1)
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/unit/engines/gateway/test_query_understanding.py
+++ b/tests/unit/engines/gateway/test_query_understanding.py
@@ -1,0 +1,194 @@
+"""QueryUnderstandingEngine 单元测试。"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from hivememory.core.models import Identity, LogicalBlock, TopicData, TurnRecord
+from hivememory.core.protocol.gateway import IntentType, MemoryWriteSignal
+from hivememory.engines.gateway.query_understanding import (
+    QueryUnderstandingEngine,
+    QueryUnderstandingError,
+)
+from hivememory.system.config import UserQueryAnalysisConfig
+
+
+def _build_topic_data() -> TopicData:
+    now = time.time()
+    return TopicData(
+        topic_id="topic-1",
+        user_id="u1",
+        topic_title="Docker 部署",
+        topic_summary="排查 Docker 部署问题",
+        state_summary="已定位到内存溢出",
+        blocks=(
+            LogicalBlock(
+                turn=TurnRecord(
+                    identity=Identity(user_id="u1"),
+                    user_query="那个报错怎么修？",
+                    assistant_final_text="可以增加内存限制",
+                )
+            ),
+        ),
+        last_update=now,
+        last_accessed_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_analyze_parses_shared_result_and_renders_context() -> None:
+    llm = AsyncMock()
+    llm.acomplete_json.return_value = (
+        '{"intent_type":"RAG",'
+        '"rewritten_query":"Docker OOM 内存溢出报错的排查原因与修复方案",'
+        '"search_keywords":["Docker","OOM","内存溢出"],'
+        '"memory_write_signal":"WRITE",'
+        '"sub_intents":[],'
+        '"reason":"技术问答"}'
+    )
+    engine = QueryUnderstandingEngine(
+        config=UserQueryAnalysisConfig(), llm_service=llm
+    )
+
+    result = await engine.analyze("那个报错怎么修？", topic_data=_build_topic_data())
+
+    assert result.intent_type == IntentType.RAG
+    assert result.rewritten_query == "Docker OOM 内存溢出报错的排查原因与修复方案"
+    assert result.search_keywords == ("Docker", "OOM", "内存溢出")
+    assert result.memory_write_signal == MemoryWriteSignal.WRITE
+    assert result.sub_intents == ()
+
+    messages = llm.acomplete_json.await_args.kwargs["messages"]
+    system_prompt = messages[0]["content"]
+    assert "Docker 部署" in system_prompt
+    assert "那个报错怎么修？" in system_prompt
+    assert messages[1] == {"role": "user", "content": "那个报错怎么修？"}
+
+
+@pytest.mark.asyncio
+async def test_analyze_without_topic_data_uses_empty_context() -> None:
+    llm = AsyncMock()
+    llm.acomplete_json.return_value = (
+        '{"intent_type":"WRITE","rewritten_query":"用户偏好少盐饮食",'
+        '"search_keywords":["少盐"],"memory_write_signal":"WRITE",'
+        '"sub_intents":[],"reason":"偏好陈述"}'
+    )
+    engine = QueryUnderstandingEngine(
+        config=UserQueryAnalysisConfig(), llm_service=llm
+    )
+
+    result = await engine.analyze("以后做菜少放盐", topic_data=None)
+
+    assert result.intent_type == IntentType.WRITE
+    messages = llm.acomplete_json.await_args.kwargs["messages"]
+    assert "{topic_context}" not in messages[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_analyze_applies_lenient_defaults_for_optional_fields() -> None:
+    llm = AsyncMock()
+    llm.acomplete_json.return_value = (
+        '{"intent_type":"NOT_A_REAL_INTENT","rewritten_query":"重写结果",'
+        '"search_keywords":"not-a-list","memory_write_signal":"BAD",'
+        '"sub_intents":null}'
+    )
+    engine = QueryUnderstandingEngine(
+        config=UserQueryAnalysisConfig(), llm_service=llm
+    )
+
+    result = await engine.analyze("查询", topic_data=None)
+
+    assert result.intent_type == IntentType.RAG
+    assert result.memory_write_signal == MemoryWriteSignal.UNKNOWN
+    assert result.search_keywords == ()
+    assert result.sub_intents == ()
+
+
+@pytest.mark.asyncio
+async def test_analyze_respects_configurable_context_limits() -> None:
+    llm = AsyncMock()
+    llm.acomplete_json.return_value = (
+        '{"intent_type":"RAG","rewritten_query":"重写结果",'
+        '"search_keywords":[],"memory_write_signal":"UNKNOWN",'
+        '"sub_intents":[],"reason":""}'
+    )
+    engine = QueryUnderstandingEngine(
+        config=UserQueryAnalysisConfig(context_block_limit=0, context_text_limit=4),
+        llm_service=llm,
+    )
+
+    await engine.analyze("查询", topic_data=_build_topic_data())
+
+    system_prompt = llm.acomplete_json.await_args.kwargs["messages"][0]["content"]
+    # block_limit=0 时不渲染任何历史轮次
+    assert "user: " not in system_prompt
+    assert "assistant: " not in system_prompt
+    # 标题与摘要仍渲染
+    assert "Docker 部署" in system_prompt
+
+    engine = QueryUnderstandingEngine(
+        config=UserQueryAnalysisConfig(context_block_limit=1, context_text_limit=4),
+        llm_service=llm,
+    )
+
+    now = time.time()
+    topic_data = TopicData(
+        topic_id="topic-1",
+        user_id="u1",
+        topic_title="三餐推荐",
+        blocks=(
+            LogicalBlock(
+                turn=TurnRecord(
+                    identity=Identity(user_id="u1"),
+                    user_query="上一轮用户输入的很长内容",
+                    assistant_final_text="",
+                )
+            ),
+        ),
+        last_update=now,
+        last_accessed_at=now,
+    )
+
+    await engine.analyze("查询", topic_data=topic_data)
+
+    system_prompt = llm.acomplete_json.await_args.kwargs["messages"][0]["content"]
+    # text_limit=4 时历史文本被截断
+    assert "user: 上一轮用" in system_prompt
+    assert "上一轮用户输入的很长内容" not in system_prompt
+
+
+@pytest.mark.asyncio
+async def test_analyze_raises_without_llm_service() -> None:
+    engine = QueryUnderstandingEngine(
+        config=UserQueryAnalysisConfig(), llm_service=None
+    )
+
+    with pytest.raises(QueryUnderstandingError):
+        await engine.analyze("查询", topic_data=None)
+
+
+@pytest.mark.asyncio
+async def test_analyze_raises_on_missing_rewritten_query() -> None:
+    llm = AsyncMock()
+    llm.acomplete_json.return_value = '{"intent_type":"RAG","rewritten_query":"  "}'
+    engine = QueryUnderstandingEngine(
+        config=UserQueryAnalysisConfig(), llm_service=llm
+    )
+
+    with pytest.raises(QueryUnderstandingError):
+        await engine.analyze("查询", topic_data=None)
+
+
+@pytest.mark.asyncio
+async def test_analyze_wraps_llm_failure() -> None:
+    llm = AsyncMock()
+    llm.acomplete_json.side_effect = RuntimeError("boom")
+    engine = QueryUnderstandingEngine(
+        config=UserQueryAnalysisConfig(), llm_service=llm
+    )
+
+    with pytest.raises(QueryUnderstandingError, match="boom"):
+        await engine.analyze("查询", topic_data=None)

--- a/tests/unit/gateway/test_phase3c_workflow.py
+++ b/tests/unit/gateway/test_phase3c_workflow.py
@@ -219,7 +219,7 @@ async def test_declared_fallbacks_form_a_complete_conservative_decision() -> Non
     assert result.decision.intent_type == IntentType.RAG
     assert result.decision.rewritten_query == "需要检索的问题"
     assert result.decision.search_keywords == ()
-    assert result.decision.memory_write_signal == MemoryWriteSignal.WRITE
+    assert result.decision.memory_write_signal == MemoryWriteSignal.UNKNOWN
     assert result.decision.retrieval_plan.mode == RetrievalMode.HYBRID
     assert events.events[0].event_type == (
         RuntimeEventType.GATEWAY_WORKFLOW_STARTED.value

--- a/tests/unit/gateway/test_phase3e_analysis_resolver.py
+++ b/tests/unit/gateway/test_phase3e_analysis_resolver.py
@@ -2,22 +2,27 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import AsyncMock
 
 import pytest
 
-from hivememory.core.models import Identity
+from hivememory.core.models import Identity, LogicalBlock, TopicData, TurnRecord
 from hivememory.core.protocol.gateway import (
     GatewayIngressMode,
     IntentType,
     MemoryWriteSignal,
     RetrievalMode,
 )
+from hivememory.engines.gateway.models import QueryUnderstandingResult
+from hivememory.engines.gateway.query_understanding import QueryUnderstandingError
 from hivememory.gateway.analysis import (
     FallbackUserQueryAnalysisResolver,
+    LLMUserQueryAnalysisResolver,
     UserQueryAnalysisContext,
 )
 from hivememory.gateway.context import CandidateTopics
+from hivememory.gateway.errors import RecoverableGatewayError
 from hivememory.gateway.runtime import GatewayRuntime
 from hivememory.gateway.service import GatewayService
 from hivememory.patchouli.contracts import PatchouliRoutes
@@ -27,17 +32,62 @@ from hivememory.system.runtime.bus.global_bus import GlobalSystemBus
 from hivememory.system.runtime.events import RecordingRuntimeEventSink
 
 
+def _build_context(raw_message: str, **overrides) -> UserQueryAnalysisContext:
+    kwargs = {
+        "raw_message": raw_message,
+        "identity": Identity(user_id="u1"),
+        "candidate_topics": CandidateTopics(),
+        "topic_id": "NEW_TOPIC",
+    }
+    kwargs.update(overrides)
+    return UserQueryAnalysisContext(**kwargs)
+
+
+def _build_topic_data(last_user_query: str = "") -> TopicData:
+    now = time.time()
+    return TopicData(
+        topic_id="topic-1",
+        user_id="u1",
+        topic_title="三餐推荐",
+        blocks=(
+            LogicalBlock(
+                turn=TurnRecord(
+                    identity=Identity(user_id="u1"),
+                    user_query=last_user_query,
+                    assistant_final_text="好的",
+                )
+            ),
+        )
+        if last_user_query
+        else (),
+        last_update=now,
+        last_accessed_at=now,
+    )
+
+
+def _build_engine_mock(
+    result: QueryUnderstandingResult | None = None,
+    error: Exception | None = None,
+) -> AsyncMock:
+    engine = AsyncMock()
+    if error is not None:
+        engine.analyze.side_effect = error
+    else:
+        engine.analyze.return_value = result or QueryUnderstandingResult(
+            intent_type=IntentType.RAG,
+            rewritten_query="重写后的查询",
+            search_keywords=("关键词",),
+            memory_write_signal=MemoryWriteSignal.WRITE,
+        )
+    return engine
+
+
 @pytest.mark.asyncio
 async def test_fallback_resolver_returns_fixed_conservative_result() -> None:
     resolver = FallbackUserQueryAnalysisResolver(
         UserQueryAnalysisConfig(default_top_k=11)
     )
-    context = UserQueryAnalysisContext(
-        raw_message="不要改写这个问题",
-        identity=Identity(user_id="u1"),
-        candidate_topics=CandidateTopics(),
-        topic_id="NEW_TOPIC",
-    )
+    context = _build_context("不要改写这个问题")
 
     result = await resolver.resolve(context)
 
@@ -50,14 +100,111 @@ async def test_fallback_resolver_returns_fixed_conservative_result() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runtime_uses_topic_router_and_normal_fallback_resolver() -> None:
+async def test_llm_resolver_maps_engine_result() -> None:
+    engine = _build_engine_mock()
+    resolver = LLMUserQueryAnalysisResolver(
+        config=UserQueryAnalysisConfig(), engine=engine
+    )
+
+    result = await resolver.resolve(_build_context("那个报错怎么修"))
+
+    assert result.intent_type == IntentType.RAG
+    assert result.rewritten_query == "重写后的查询"
+    assert result.search_keywords == ("关键词",)
+    assert result.memory_write_signal == MemoryWriteSignal.WRITE
+    assert result.retrieval_plan.mode == RetrievalMode.HYBRID
+
+
+@pytest.mark.asyncio
+async def test_llm_resolver_rule_overrides_explicit_write_intent() -> None:
+    engine = _build_engine_mock()
+    resolver = LLMUserQueryAnalysisResolver(
+        config=UserQueryAnalysisConfig(), engine=engine
+    )
+
+    result = await resolver.resolve(_build_context("记住我不吃香菜"))
+
+    assert result.intent_type == IntentType.WRITE
+    assert result.memory_write_signal == MemoryWriteSignal.WRITE
+    assert result.retrieval_plan.mode == RetrievalMode.SKIP
+    assert result.retrieval_plan.top_k == 0
+
+
+@pytest.mark.asyncio
+async def test_llm_resolver_rule_marks_repeated_input_skip() -> None:
+    engine = _build_engine_mock()
+    resolver = LLMUserQueryAnalysisResolver(
+        config=UserQueryAnalysisConfig(), engine=engine
+    )
+    context = _build_context(
+        "晚饭吃什么",
+        topic_id="topic-1",
+        routed_topic_data=_build_topic_data(last_user_query="晚饭吃什么"),
+    )
+
+    result = await resolver.resolve(context)
+
+    assert result.memory_write_signal == MemoryWriteSignal.SKIP
+    assert result.intent_type == IntentType.RAG
+
+
+@pytest.mark.asyncio
+async def test_llm_resolver_derives_dense_mode_without_keywords() -> None:
+    engine = _build_engine_mock(
+        result=QueryUnderstandingResult(
+            intent_type=IntentType.RAG,
+            rewritten_query="重写后的查询",
+            search_keywords=(),
+            memory_write_signal=MemoryWriteSignal.UNKNOWN,
+        )
+    )
+    resolver = LLMUserQueryAnalysisResolver(
+        config=UserQueryAnalysisConfig(default_top_k=7), engine=engine
+    )
+
+    result = await resolver.resolve(_build_context("随便聊聊热点新闻"))
+
+    assert result.retrieval_plan.mode == RetrievalMode.DENSE
+    assert result.retrieval_plan.top_k == 7
+
+
+@pytest.mark.asyncio
+async def test_llm_resolver_converts_engine_error_to_recoverable() -> None:
+    engine = _build_engine_mock(error=QueryUnderstandingError("解析失败"))
+    events = RecordingRuntimeEventSink()
+    resolver = LLMUserQueryAnalysisResolver(
+        config=UserQueryAnalysisConfig(),
+        engine=engine,
+        runtime_events=events,
+    )
+
+    with pytest.raises(RecoverableGatewayError, match="解析失败"):
+        await resolver.resolve(_build_context("查询"))
+
+    capability_events = [
+        event
+        for event in events.events
+        if event.event_type
+        == RuntimeEventType.GATEWAY_ANALYSIS_CAPABILITY_COMPLETED.value
+    ]
+    assert len(capability_events) == 1
+    assert capability_events[0].data["error"] == "解析失败"
+
+
+@pytest.mark.asyncio
+async def test_runtime_uses_topic_router_and_llm_resolver() -> None:
     bus = GlobalSystemBus()
     events = RecordingRuntimeEventSink()
     llm_service = AsyncMock()
-    llm_service.acomplete_json.return_value = (
-        '{"target_topic":"NEW_TOPIC","new_topic_title":"保守分析",'
-        '"new_topic_summary":"验证查询分析兜底策略","reason":"无匹配话题"}'
-    )
+    llm_service.acomplete_json.side_effect = [
+        '{"target_topic":"NEW_TOPIC","new_topic_title":"查询分析",'
+        '"new_topic_summary":"验证查询分析解析器","reason":"无匹配话题"}',
+        '{"intent_type":"RAG",'
+        '"rewritten_query":"标准查询的重写结果",'
+        '"search_keywords":["标准查询"],'
+        '"memory_write_signal":"WRITE",'
+        '"sub_intents":[],"reason":"技术问答"}',
+    ]
 
     async def list_active_topics(**_kwargs):
         return ()
@@ -79,9 +226,12 @@ async def test_runtime_uses_topic_router_and_normal_fallback_resolver() -> None:
     )
 
     assert result.kind == "decision"
-    assert result.decision.rewritten_query == "继续处理标准查询"
+    assert result.decision.rewritten_query == "标准查询的重写结果"
+    assert result.decision.search_keywords == ("标准查询",)
+    assert result.decision.memory_write_signal == MemoryWriteSignal.WRITE
+    assert result.decision.retrieval_plan.mode == RetrievalMode.HYBRID
     assert result.decision.retrieval_plan.top_k == 9
-    assert llm_service.acomplete_json.await_count == 1
+    assert llm_service.acomplete_json.await_count == 2
     completed = [
         event
         for event in events.events
@@ -89,3 +239,46 @@ async def test_runtime_uses_topic_router_and_normal_fallback_resolver() -> None:
     ]
     assert completed[-1].data["step_id"] == "user_query_analysis"
     assert completed[-1].data["is_fallback"] is False
+    capability_events = [
+        event
+        for event in events.events
+        if event.event_type
+        == RuntimeEventType.GATEWAY_ANALYSIS_CAPABILITY_COMPLETED.value
+    ]
+    assert len(capability_events) == 1
+    assert capability_events[0].data["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_falls_back_to_conservative_result_on_analysis_error() -> None:
+    bus = GlobalSystemBus()
+    llm_service = AsyncMock()
+    llm_service.acomplete_json.side_effect = [
+        '{"target_topic":"NEW_TOPIC","new_topic_title":"查询分析",'
+        '"new_topic_summary":"验证查询分析兜底","reason":"无匹配话题"}',
+        '{"intent_type":"RAG","rewritten_query":"  "}',
+    ]
+
+    async def list_active_topics(**_kwargs):
+        return ()
+
+    bus.register(PatchouliRoutes.TOPIC_LIST_ACTIVE, list_active_topics)
+    runtime = GatewayRuntime(
+        config=SystemGatewayConfig(
+            user_query_analysis=UserQueryAnalysisConfig(default_top_k=9)
+        ),
+        global_bus=bus,
+        llm_service=llm_service,
+    )
+
+    result = await GatewayService(runtime).process(
+        "继续处理标准查询",
+        identity=Identity(user_id="u1"),
+        ingress_mode=GatewayIngressMode.ACTIVE_CHAT,
+    )
+
+    assert result.kind == "decision"
+    assert result.decision.rewritten_query == "继续处理标准查询"
+    assert result.decision.memory_write_signal == MemoryWriteSignal.UNKNOWN
+    assert result.decision.retrieval_plan.mode == RetrievalMode.HYBRID
+    assert result.decision.retrieval_plan.top_k == 9


### PR DESCRIPTION
## 描述

恢复旧gateway LLM Analyzer的所有功能，包括query重写，意图识别，记忆价值判断等，仍然保持单次内完成，避免成本爆炸

## 类型

- [ ] Bug 修复 (fix)
- [x] 新功能 (feat)
- [ ] 代码重构 (refactor)
- [ ] 文档更新 (docs)
- [ ] 代码风格更新 (style)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 构建/CI 更新 (build/ci)
- [ ] 其他变更 (chore)

## 相关 Issue

无

## 检查清单

- [x] 我已经阅读了项目的贡献指南
- [x] 我已经自我审查了代码，并确保其符合项目的代码风格与规范
- [x] 代码通过了 lint 检查
- [x] 添加了必要的测试用例并全部通过
- [x] 文档已更新（如有必要）

## 测试

添加并运行了已有测试

## 附加信息

以上功能是否需要独立决策引擎需待真实体验评估后完成
