### PR TITLE
Refactor/chat run cancel

### DIFF
--- a/docs/alice/README.md
+++ b/docs/alice/README.md
@@ -174,7 +174,7 @@ AliceRuntime 还订阅 PatchouliBridge 发布的 PendingAtom settled/failed/canc
 - AgentProfile cache 是进程内、按 Identity + alias 隔离的 32 项 LRU，但仍没有 TTL、更新事件或显式失效入口；Profile 修改可能在进程内长期不可见；
 - `ExecutionFrame.identity` 在子帧中继承父帧，`AgentProfile` 又不携带解析 alias；因此部分子帧流事件和 PendingAtom provenance 会记录父 Agent，而不是实际 CALL 目标；
 - KoakumaAtomCache 与 PendingAtomRuntime 都由 AliceRuntime 进程级共享。L0/L1 alias 命中当前不会再次校验调用 Identity，尚未满足跨用户并发运行所需的隔离；
-- 每次 run 的 frame registry、CallRecord 与 cancel event 由独立 `RunSession` 持有，stream sequence 由流式输出端口持有；`RunExecutor` 用协程递归表达 CALL 的挂起与重入，不维护单活动 frame 状态机；
+- 每次 run 的 frame registry 与 CallRecord 由独立 `RunSession` 持有，stream sequence 由流式输出端口持有；`RunExecutor` 用协程递归表达 CALL 的挂起与重入，不维护单活动 frame 状态机；Chat application 在更上层拥有可取消阶段 task。
 - 子 Agent 异常会被包装为 CALL error 交给主 Agent 继续处理；取消、预算耗尽和意外挂起分别保持 cancelled 或稳定 error，不会被视作成功返回；
 - Agent frame、PendingAtom、alias cache 与 Profile cache 均不持久化，进程重启后不能恢复；统一恢复边界见[运行时状态持久化与故障恢复计划](../plans/runtime-state-durability-and-recovery.md)；
 - Alice 当前只有单层 CALL，不具备持久化 DAG、并行 specialist、review loop、配额或 backpressure；

--- a/docs/alice/agent-runtime.md
+++ b/docs/alice/agent-runtime.md
@@ -12,7 +12,7 @@ related_contracts:
   - docs/contracts/subsystem-contracts.md
   - docs/contracts/mtp.md
   - docs/contracts/error-model.md
-last_reviewed: 2026-08-04
+last_reviewed: 2026-08-05
 ---
 
 # Agent Runtime
@@ -147,7 +147,7 @@ Agent Runtime 不再直接构造 SSE dict，也不依赖名为 EventBus/Sink 的
 
 交互输出流与 RuntimeEvent 是两条严格独立的数据面。前者面向当前调用方，参与背压和断流取消，不能丢弃，并保留 `token/mtp_start/mtp_result/sub_agent_start/sub_agent_end/done` 兼容事件名；后者是全局 best-effort 观测旁路，可以缓冲、回放和丢弃慢订阅者数据，只记录 `agent.run.*` 等生命周期摘要。FrameOutput 不会自动桥接到 RuntimeEventBus，RuntimeEvent 也不驱动 frame、CALL 或 run 状态。
 
-非流式 LiteLLM await、流式 async iterator 的每次 pull，以及 MTP await 都直接响应外层 task cancellation。Worker 在流式 iterator 的 `finally` 中关闭底层 iterator；同步 syscall 一旦开始执行，事件循环仍必须等待函数返回，这属于 Python task cancellation 无法解决的同步边界。
+非流式 LiteLLM await、流式 async iterator 的每次 pull，以及 MTP await 都直接响应外层 task cancellation。Agent loop 在 `finally` 中关闭 Worker generator，Worker 再关闭 LiteLLM/provider response；各层 close 失败只记录日志，不能替换正在传播的 `CancelledError`。RunExecutor 的 CALL/run 收尾遵循同一优先级：先做 best-effort 本地清理，再原样重抛取消。同步 syscall 一旦开始执行，事件循环仍必须等待函数返回，这属于 Python task cancellation 无法解决的同步边界。
 
 ## 7. AgentRunResult 的组装边界
 

--- a/docs/alice/agent-runtime.md
+++ b/docs/alice/agent-runtime.md
@@ -43,7 +43,7 @@ AgentRunService
 
 `AgentRuntime` 门面与 frame 级稳定契约保留在 `agent_runtime/` 根部；`execution/` 收拢 loop 与 WorkerAgent，`aliases/` 收拢热缓存和三级解析，`mtp/`、`pending_atom/` 分别保存协议执行与写缓冲能力。AliceRuntime 在进程启动时构造这组资源，AgentRunService 把同一个门面交给每次 run 的 RunExecutor；执行层不再位于 Alice 编排目录中。
 
-当前对外只有一个 frame 执行入口：`AgentRuntime.run_frame(frame, *, generation_options, output_sink, cancel_event)`。非流式与流式调用分别注入 `NullFrameOutputSink` 和支持 token 的 frame output sink，但共享同一条 loop 与 `FrameExecutionResult` 语义；旧的 `run_frame_stream()`、`run_frame_emitting()` 与 callback adapter 已删除。Agent Runtime 不接收额外的 generation mode，而是只读取 `output_sink.streams_tokens`：为 `false` 时调用完整生成，为 `true` 时调用 token stream。
+当前对外只有一个 frame 执行入口：`AgentRuntime.run_frame(frame, *, generation_options, output_sink)`。非流式与流式调用分别注入 `NullFrameOutputSink` 和支持 token 的 frame output sink，但共享同一条 loop 与 `FrameExecutionResult` 语义；旧的 `run_frame_stream()`、`run_frame_emitting()` 与 callback adapter 已删除。Agent Runtime 不接收 Chat Run 取消句柄，也不轮询取消状态；外层 task cancellation 直接沿 await 传播。Agent Runtime 不接收额外的 generation mode，而是只读取 `output_sink.streams_tokens`：为 `false` 时调用完整生成，为 `true` 时调用 token stream。
 
 ## 2. ExecutionFrame：可恢复的运行 PCB
 
@@ -110,17 +110,16 @@ session generation_options
 默认最大循环次数为 10。每轮执行：
 
 ```text
-1. check cancel
-2. WorkerAgent generate with stop=["⟫"]
-3. natural output?
+1. WorkerAgent generate with stop=["⟫"]
+2. natural output?
      -> append assistant text/event -> complete
-4. MTP fragment?
+3. MTP fragment?
      -> build action-scoped MTPExecutionContext
      -> Koakuma execute
      -> append tool_call event
-5. response == suspend?
+4. response == suspend?
      -> return FrameExecutionResult(SUSPENDED)
-6. ordinary result
+5. ordinary result
      -> append assistant command + formatted tool result to history
      -> append tool_result event
      -> continue
@@ -142,13 +141,13 @@ Agent Runtime 不再直接构造 SSE dict，也不依赖名为 EventBus/Sink 的
 - 被调用 frame 事件仍使用相同类型，通过 `scope/frame_id/action_id/agent_id` 命名空间区分；为兼容既有 SSE 客户端，Alice 仍可提供 `depth` 展示字段，但它不再参与 Runtime 控制流；
 - `done` 由 AgentRunService 在 RunExecutor 完成主 run 收尾后组装，而不是由 WorkerAgent 直接发出。
 
-每次流式 run 由 `AgentRunStreamAdapter` 创建容量为 256 的有界 FIFO queue、runner task 与 run-local `stream_sequence`。`QueueAgentRunOutput` 使用 `await put()` 保留背压，不丢弃 token 或控制事件；消费者提前关闭时，适配器设置当前 `RunSession.cancel_event` 并取消当前 runner，不影响其他 run。RunExecutor 本身没有 `run_stream()`、queue 或 sequence，它只调用统一的 `run(..., run_output=...)`。
+每次流式 run 由 `AgentRunStreamAdapter` 创建容量为 256 的有界 FIFO queue、runner task 与 run-local `stream_sequence`。`QueueAgentRunOutput` 使用 `await put()` 保留背压，不丢弃 token 或控制事件；消费者提前关闭时，适配器取消并 join 自己创建的 runner，不影响其他 run。RunExecutor 本身没有 `run_stream()`、queue 或 sequence，它只调用统一的 `run(..., run_output=...)`。
 
 检测到 MTP 后，本轮剩余协议文本不再作为普通 token 推给用户，而是等待 Runtime 执行并发出结构化输出。CALL 时，`RunExecutor` 取得 `SUSPENDED` 结果，调用 `CallCoordinator.begin_call()`；Coordinator 先通过 `CallContextProvider` 获得目标 Profile 和共享上下文，再准备 callee。随后 Executor 递归等待同一个 `_execute_frame(callee)`，返回后调用 `complete_call()`，最后通过 `AgentRuntime.apply_call_response()` 重入同一个 caller frame。Runtime 不感知入口/被调用角色，挂起关系由 Executor 的协程调用栈表达。
 
 交互输出流与 RuntimeEvent 是两条严格独立的数据面。前者面向当前调用方，参与背压和断流取消，不能丢弃，并保留 `token/mtp_start/mtp_result/sub_agent_start/sub_agent_end/done` 兼容事件名；后者是全局 best-effort 观测旁路，可以缓冲、回放和丢弃慢订阅者数据，只记录 `agent.run.*` 等生命周期摘要。FrameOutput 不会自动桥接到 RuntimeEventBus，RuntimeEvent 也不驱动 frame、CALL 或 run 状态。
 
-非流式 LiteLLM 请求会与 `cancel_event.wait()` 竞争，取消时主动 cancel completion task。流式请求在每个 chunk 边界检查 cancel_event；MTP handler 又在执行前后检查，但同步 syscall 运行期间不能被这些 checkpoint 强制打断。
+非流式 LiteLLM await、流式 async iterator 的每次 pull，以及 MTP await 都直接响应外层 task cancellation。Worker 在流式 iterator 的 `finally` 中关闭底层 iterator；同步 syscall 一旦开始执行，事件循环仍必须等待函数返回，这属于 Python task cancellation 无法解决的同步边界。
 
 ## 7. AgentRunResult 的组装边界
 

--- a/docs/alice/mtp-runtime.md
+++ b/docs/alice/mtp-runtime.md
@@ -126,9 +126,9 @@ READ 正式 atom/redirect 与 RUN code atom 会请求 Patchouli 记录 citation�
 
 ## 7. 取消边界
 
-Koakuma 在拦截命令前和 handler 分发前检查本次调用显式传入的 `cancel_event`；Agent loop 也在生成前后与 MTP 执行前后设置 checkpoint。命中取消时返回 `cancelled`，frame 随后由 Agent Runtime 结束，不应转换成普通 success。MTPExecutor 和 Koakuma 不再保存跨 run 的共享 cancel 字段。
+Koakuma、MTPExecutor 和 Agent loop 不接收 Chat Run 取消句柄，也不定义取消协议。Chat application 取消等待中的 Agent task 后，原生 `asyncio.CancelledError` 直接穿过 MTP await；不得转换为普通 success，也不得构造 Chat-level cancelled 哨兵。内部已经结算的 `FrameExecutionStatus.CANCELLED` 仍可用于 frame finalize 和 CALL response 映射，但不能吞掉 task cancellation。
 
-这是一种协作式取消。同步 syscall 一旦开始执行，事件循环必须等待函数返回；REPL 自身的 subprocess timeout 能终止超时子进程，但普通 cancel_event 不能在运行中立即打断它。文件 I/O 和 web search 同样没有中途取消 checkpoint。
+同步 syscall 一旦开始执行，事件循环必须等待函数返回；REPL 自身的 subprocess timeout 能终止超时子进程，但 Python task cancellation 不能在运行中强制打断同步代码。文件 I/O 和 web search 同样没有中途抢占点。
 
 ## 8. 配置与实际接线
 
@@ -184,13 +184,13 @@ Alice 配置当前分为两组：
 - `execution_timeout_seconds` 没有包住 `execute_mtp()`，`tool_cache_size` 也未接入任何 cache；配置存在不代表能力已实现；
 - `web_search_timeout_seconds` 虽被传进 syscall registry，但 `sys_web_search()` 明确忽略该参数；底层调用可能超过配置时间；
 - Kernel syscalls 是同步函数，并在 async handler 中直接执行。文件、搜索和 subprocess 等工作会阻塞当前事件循环；
-- cancel token 按 `intercept_and_execute(..., cancel_event=...)` 逐次传入，不再保存在共享 KoakumaRuntime 字段中；仍需通过并发回归测试持续验证 run-local 隔离；
-- 同步 syscall 执行期间不会轮询 cancel_event，因此协作式取消不能立即中断文件或网络调用；
+- MTP 调用不携带 Chat Run 取消参数；取消边界由拥有该 await 的外层 task 负责；
+- 同步 syscall 执行期间不会轮询取消状态，因此 task cancellation 不能立即中断文件或网络调用；
 - PromptBuilder 会按白名单过滤主要动词说明和工具菜单，但 dense one-shot demo 没有完整按 denied verbs 裁剪。例如禁止 RUN 时，示例中仍可能出现 RUN；
 - prompt 的默认工具菜单来自静态 `DEFAULT_RUNTIME_TOOLS`，不是从实际 Kernel Registry 动态生成。注册表与提示词可能漂移；
 - RuntimeAliasResolver 的 L0 PendingAtom 和 L1 atom cache 命中不重新校验 Identity。当前代码尚未完全兑现 MTP 契约中“记忆访问使用调用方 Identity”的不变量；
 - RUN 的受限子进程不是面向敌对输入的安全沙箱，也没有来源签名、资源配额与 OS 级隔离；
 - Agent loop 达到 `max_loop_iterations` 后返回 `BUDGET_EXHAUSTED`，根 run 对外映射为 `AgentRunStatus.FAILED`，CALL callee 映射为稳定的 budget error；
-- Koakuma、atom cache 与 PendingAtomRuntime 的共享服务仍属于 Alice 组合根，但 frame registry、CALL ledger、cancel event 与 stream sequence 已按 run 隔离。
+- Koakuma、atom cache 与 PendingAtomRuntime 的共享服务仍属于 Alice 组合根，但 frame registry、CALL ledger 与 stream sequence 已按 run 隔离。
 
 当前 MTP Runtime 已经形成“文本协议、结构化解析、双层权限、受控 handler 与可恢复错误”的完整闭环，但它仍是面向单进程可信部署的实验性执行层。文档和上层产品都不应把它包装成强隔离插件平台、持久化工作流引擎或任意代码安全沙箱。

--- a/docs/alice/orchestration.md
+++ b/docs/alice/orchestration.md
@@ -36,7 +36,7 @@ AliceSystem
   ├─ AgentRunService
   │    ├─ public run API / root frame bootstrap / AgentRunResult / stream done
   │    ├─ RunSession
-  │    │    └─ frame registry / CallRecord ledger / cancel event
+  │    │    └─ frame registry / CallRecord ledger
   │    ├─ RunExecutor
   │    │    └─ recursive frame evaluation + run finalization
   │    ├─ CallCoordinator
@@ -104,7 +104,7 @@ current frame emits CALL
   -> call_response maps the finalized result to one MTPCallResponse
   -> AgentRuntime.apply_call_response() commits the response once
   -> emit sub_agent_end
-  -> return ResumeCaller, or CancelRun after a cancelled response
+  -> return ResumeCaller; task cancellation unwinds the recursive call stack
 ```
 
 `suspend` 不能被当作一条正文为空的成功响应。如果执行循环直接继续，Agent 会在被调用任务尚未执行时向下生成，CALL 的任务身份、结果和取消边界都会丢失。RunExecutor 必须先等待被调用任务完成，再以同一 action_id 通过 `AgentRuntime.apply_call_response()` 回填 tool result。
@@ -204,8 +204,8 @@ caller 与 callee 共享 run_id，因此最终物化任务不依赖这份 IPC ha
 - CallContextProvider 的 Profile/共享上下文解析错误，以及后续模型调用或执行异常，会在 CALL 边界形成 error `MTPCallResponse`，主 Agent 得到错误后可以调整方案；
 - 子帧预算耗尽映射为 `mtp.call_response.budget_exhausted`，子帧取消保持 cancelled 终态；生产 policy 会在 Agent loop 内拒绝被调用 frame 的 CALL，因此不会形成第二层 suspension；若未来开放该权限，RunExecutor 会直接递归执行，而不需要增加 root/callee 状态分支；
 - 无法解析的单个 context ref 只跳过，不使 CALL 失败；
-- run 取消 token 会传给主/子 AgentRuntime；活动 CALL 先 exactly-once 回填 cancelled response 并把 record 标记为 applied，再以 `CancelRun` 终止递归执行，不重入 caller 继续生成；最终主结果为 cancelled，并取消本 run 尚未结算的 PendingAtom，不交出 materialize tasks；
-- 流生成器提前关闭时，AgentRunService 设置当前 RunSession 的 cancel token，并关闭 AgentRunStream；适配器取消 runner task，CancelledError 沿递归协程栈展开，各层清理尚未 apply 的 CALL 并回填 cancelled response，最外层只收尾整个 run 一次，且不再向关闭的 consumer 阻塞发送事件；
+- Chat application 不向主/子 AgentRuntime 传递取消 token。用户 stop 取消当前 Alice task；RunExecutor 捕获 `CancelledError` 做本地 unwind，活跃 CALL 只清理 callee frame 和 record，不伪造 caller response，最外层收尾整个 run 一次，并保留原生异常传播；
+- 流生成器提前关闭时，`AgentRunStream` 取消并 join 自己创建的 runner；`CancelledError` 沿递归协程栈展开，各层清理尚未 apply 的 CALL，且不再向关闭的 consumer 阻塞发送事件；
 - 子 Agent 没有独立的公开取消句柄、重试策略或超时配置，生命周期依附于父 run。
 
 将子 Agent 失败包装成 CALL error 是局部容错，不代表子任务成功；主 Agent 是否还能完成用户请求由后续生成决定。相反，主 frame 基础设施失败没有可用的上层 Agent 继续纠正，因此必须结束本次 run。
@@ -225,7 +225,7 @@ caller 与 callee 共享 run_id，因此最终物化任务不依赖这份 IPC ha
 
 - AgentProfile cache 已按 Identity + alias 隔离、上限固定为 32，但没有 TTL、版本检查或管理事件失效；Profile 更新要等 LRU 淘汰或进程重启才可靠生效；
 - `AgentProfile` 模型不保存来源 atom alias，子 frame 又继承父 Identity。执行层子事件可能把 `agent_id` 标为父 Agent，子帧创建的 PendingAtom 也无法仅凭 Identity 证明真实 CALL 目标；
-- frame registry、CallRecord 与 cancel event 由每次 run 新建的 `RunSession` 持有；执行位置由 RunExecutor 的协程调用栈表达；stream sequence 由每次流式 run 独占的 `QueueAgentRunOutput` 持有，当前没有共享 frame stack、活动 frame 状态机或共享输出队列；
+- frame registry 与 CallRecord 由每次 run 新建的 `RunSession` 持有；执行位置由 RunExecutor 的协程调用栈表达；stream sequence 由每次流式 run 独占的 `QueueAgentRunOutput` 持有，当前没有共享 frame stack、活动 frame 状态机或共享输出队列；
 - context ref 跳过只写日志，CALL response 没有 partial warning 列表；
 - 子任务没有持久化 task id、独立 timeout/retry、并发额度、结果 artifact 或恢复机制；
 - 当前产品 policy 只允许串行单层 CALL；RunExecutor 已能递归求值 frame，但尚未开放嵌套 CALL，也没有 parallel fan-out、动态 DAG、review loop 或 Alice 自主规划。

--- a/docs/alice/orchestration.md
+++ b/docs/alice/orchestration.md
@@ -20,7 +20,7 @@ related_contracts:
   - docs/contracts/mtp.md
   - docs/contracts/subsystem-contracts.md
   - docs/contracts/error-model.md
-last_reviewed: 2026-08-04
+last_reviewed: 2026-08-05
 ---
 
 # 多 Agent 编排
@@ -56,7 +56,7 @@ AliceSystem
 
 - AgentRunService 是 Alice 的公开 run 用例入口，负责创建入口 frame、为每次 run 构造 Executor、组装 `AgentRunResult`，并在流式终态后发出唯一 `done`；queue、runner task、stream sequence 与 RuntimeEvent envelope 实现均不放在 application 层；
 - AliceSystem 是子系统装配根；AliceRuntime 持有进程级执行资源、AgentProfileResolver/cache 和 PendingAtom 运行时投影，不参与单次 run 的控制链；
-- RunSession 拥有一次 run 的 frame registry、CALL record 和取消信号，不保存活动 frame、frame 调度状态或传输层 stream sequence；
+- RunSession 只拥有一次 run 的 frame registry 与 CALL record，不保存取消信号、活动 frame、frame 调度状态或传输层 stream sequence；
 - RunExecutor 是唯一调用 `AgentRuntime.run_frame()` 的 Alice 编排组件。它以协程递归执行 CALL 派生 frame，并且是唯一调用 `finalize_run()` 的位置；
 - AgentRunOutput 是调度与当前请求交互输出之间的窄端口；非流式使用 null 实现，流式使用 Alice runtime 的 queue-backed 实现；
 - AgentRunStreamAdapter 只负责流式传输适配，AgentRunEventEmitter 只负责全局观测投影，两者不参与 frame 求值；
@@ -206,6 +206,7 @@ caller 与 callee 共享 run_id，因此最终物化任务不依赖这份 IPC ha
 - 无法解析的单个 context ref 只跳过，不使 CALL 失败；
 - Chat application 不向主/子 AgentRuntime 传递取消 token。用户 stop 取消当前 Alice task；RunExecutor 捕获 `CancelledError` 做本地 unwind，活跃 CALL 只清理 callee frame 和 record，不伪造 caller response，最外层收尾整个 run 一次，并保留原生异常传播；
 - 流生成器提前关闭时，`AgentRunStream` 取消并 join 自己创建的 runner；`CancelledError` 沿递归协程栈展开，各层清理尚未 apply 的 CALL，且不再向关闭的 consumer 阻塞发送事件；
+- RunExecutor、Agent loop 与 Worker 的 unwind/close 都是 best effort：清理异常记录日志，但不能替换正在传播的 `CancelledError`；
 - 子 Agent 没有独立的公开取消句柄、重试策略或超时配置，生命周期依附于父 run。
 
 将子 Agent 失败包装成 CALL error 是局部容错，不代表子任务成功；主 Agent 是否还能完成用户请求由后续生成决定。相反，主 frame 基础设施失败没有可用的上层 Agent 继续纠正，因此必须结束本次 run。
@@ -218,7 +219,7 @@ caller 与 callee 共享 run_id，因此最终物化任务不依赖这份 IPC ha
 - Profile 的 persona 不能提升结构化权限，调用方 task 也不能替被调用者改写白名单；
 - Pending alias 的 IPC 收割与 run 级 materialize task 收集是两条不同用途的数据流；
 - `context_refs` 必须经过 RuntimeAliasResolver 与 MemoryCompiler，不能通过裸 UUID 或字符串拼接绕过 alias/状态语义；
-- CALL 权限、预算与取消必须随 frame policy/session 传播，不能只依赖 prompt 告诫模型；
+- CALL 权限与预算必须随 frame policy 传播，不能只依赖 prompt 告诫模型；取消沿拥有 Alice run 的 task 递归展开，不通过 session 建立第二套控制面；
 - Alice 可以持有 Profile 运行时 cache，却不能把它当成 Patchouli 中 Profile 记忆的第二份权威事实。
 
 ## 10. 当前限制

--- a/docs/architecture/boundaries.md
+++ b/docs/architecture/boundaries.md
@@ -12,7 +12,7 @@ code_paths:
 related_contracts:
   - docs/contracts/subsystem-contracts.md
   - docs/contracts/routes-and-events.md
-last_reviewed: 2026-07-28
+last_reviewed: 2026-08-05
 ---
 
 # 系统边界与所有权
@@ -63,7 +63,7 @@ System 是舞台管理者：它知道一次完整用例需要哪些参与者、�
 ### 4.1 拥有的状态
 
 - `HiveMemorySystem` 启停状态；
-- chat generation registry 和取消信号；
+- chat generation registry，以及其中的 phase、outcome、首次 stop reason 与当前可中断阶段 task 引用；
 - Passive Ingress 的去重、turn buffer、outbox 与 drain 状态；
 - `RuntimeEventBus` 有界事件缓冲；
 - 全局维护任务注册与调度状态；
@@ -86,7 +86,7 @@ Gateway 的价值在于把不稳定、可能降级的入口分析收敛为一个
 
 ### 5.1 输入与输出
 
-Gateway 的唯一公开业务入口是 `gateway.public.process`。输入包括消息、`Identity`、`GatewayIngressMode` 以及可选取消/超时控制；输出为命令终态或普通决策终态。
+Gateway 的唯一公开业务入口是 `gateway.public.process`。输入包括消息、`Identity`、`GatewayIngressMode` 以及可选 `request_timeout_ms`；输出为命令终态或普通决策终态。Chat application 通过取消自己创建的 Gateway task 中断调用，不向 Gateway 传递控制句柄。
 
 `GatewayDecision` 只表达下游需要的稳定事实：目标话题、查询重写、关键词、记忆写入信号、检索计划和主意图。Workflow 的 step、snapshot、fallback 原因与内部分析对象不越过公共边界。
 
@@ -97,7 +97,8 @@ Gateway 的唯一公开业务入口是 `gateway.public.process`。输入包括�
 - 已路由话题加载失败：使用空话题上下文；
 - 查询分析失败：保留原始查询，使用 `RAG + HYBRID` 和默认 `top_k`；
 - step 投影、状态提交或终态不变量失败：不使用局部 fallback，整个 workflow 失败；
-- 请求取消或总 deadline 耗尽：抛出明确的 Gateway 控制错误。
+- 外层 task cancellation：原生 `asyncio.CancelledError` 直接传播，不转为 Gateway 业务错误或 fallback；
+- 总 deadline 耗尽：只有剩余步骤都有安全 fallback 时才能继续形成保守终态，否则抛出 `GatewayTimeoutError`。
 
 这些降级并不是把所有异常吞掉。候选集、辅助上下文和单项分析失败时，Gateway 仍可能形成保守而完整的决定；一旦 workflow 无法满足终态不变量，再继续返回“看起来可用”的结果只会把程序错误伪装成正常决策，因此必须让整次处理失败。
 
@@ -141,7 +142,7 @@ Alice 是知识的使用者和行动者。它可以在一次 run 中读取记忆
 ### 7.1 拥有的状态
 
 - 一次 Agent run 的 frame、消息、turn events 和终态；
-- Agent loop 的迭代、取消与流式输出；
+- Agent loop 的迭代与流式执行资源；task cancellation 的业务裁决属于 System，Alice 只负责原生传播与本地 unwind；
 - Koakuma 的 MTP parser、权限检查、alias cache 与 syscall registry；
 - PendingAtom 在当前运行期内的别名、redirect 和 terminal view；
 - CALL 的父子 frame 调度。

--- a/docs/archive/plans/README.md
+++ b/docs/archive/plans/README.md
@@ -3,7 +3,7 @@ title: Archived Plans
 status: current
 owner: project
 scope: completed-or-superseded-plans
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-05
 ---
 
 # Archived Plans
@@ -12,6 +12,7 @@ last_reviewed: 2026-08-03
 
 当前记录：
 
+- [Chat Run 取消重构最小闭环](./chat-run-cancellation-unified.md)：已完成的 phase task 控制、Gateway/Alice 原生 task cancellation、prepare 延迟响应、finalize 门禁，以及 SSE/Worker/unwind 清理加固；当前事实见 `docs/system/application-services.md`、`docs/system/runtime-and-bus.md`、`docs/gateway/`、`docs/alice/` 与 `docs/contracts/`。
 - [Alice 父子 Agent 进程调度流程收口](./alice-parent-child-run-scheduler.md)：已完成的 run-local RunScheduler、统一 root/callee 活动 frame 循环、CALL begin/complete、取消/异常收口与编排兼容层删除；当前事实见 `docs/alice/` 与 `docs/contracts/mtp.md`。
 - [Alice Agent Runtime 控制流重构](./alice-agent-runtime-control-flow-refactor.md)：已完成的单 frame runtime、run-local 编排、CALL transaction 与 PendingAtom 生命周期收口；当前事实见 `docs/alice/`。
 

--- a/docs/archive/plans/chat-run-cancellation-unified.md
+++ b/docs/archive/plans/chat-run-cancellation-unified.md
@@ -1,8 +1,9 @@
 ---
 title: Chat Run 取消重构最小闭环
-status: planned
+status: completed
 owner: system
 scope: chat-run-cancellation-minimal
+archived_at: 2026-08-05
 code_paths:
   - src/hivememory/system/application/chat_service.py
   - src/hivememory/system/runtime/control.py
@@ -24,9 +25,21 @@ last_reviewed: 2026-08-05
 
 # Chat Run 取消重构最小闭环
 
+## 实施完成记录
+
+本计划已在 `refactor/chat-run-cancel` 分支完成，实施提交从 `6fc6892`（控制契约测试）延续至
+`fb4ab51`（取消期间 cleanup 异常优先级修复），并包含 Gateway/Alice 兼容代码清理、ASGI
+断流处理、Worker stream 关闭和路由可读性整理。
+
+当前事实以 [System 应用服务](../../system/application-services.md)、
+[System 运行时与总线](../../system/runtime-and-bus.md)、[Gateway 固定工作流](../../gateway/workflow.md)、
+[Alice 多 Agent 编排](../../alice/orchestration.md)、[Agent Runtime](../../alice/agent-runtime.md)和
+[公开路由与事件](../../contracts/routes-and-events.md)为准。本文归档后只保留实施边界、设计依据与验收记录；
+未实施的生命周期候选继续由[后续设计](../../plans/chat-run-cancellation-future.md)维护。
+
 ## 1. 文档定位
 
-本文档是当前 Chat Run 取消重构的**唯一首期实施依据**。目标只有一个：
+本文档曾是 Chat Run 取消重构的**唯一首期实施依据**，现已完成。目标只有一个：
 
 > 用 `Task.cancel()` + `asyncio.CancelledError` 取代沿 Gateway、Alice、Worker、MTP、CALL 逐层传递和轮询的 `asyncio.Event`，跑通 `/chat/stop` 到 Chat 终态的最小闭环。
 
@@ -35,7 +48,7 @@ last_reviewed: 2026-08-05
 `ChatOutputChannel`、`PreparedRunLease` 或新的 SSE 协议。
 
 后续候选设计统一放入
-[Chat Run 取消与生命周期后续设计](./chat-run-cancellation-future.md)，不得反向成为首期依赖。
+[Chat Run 取消与生命周期后续设计](../../plans/chat-run-cancellation-future.md)，不得反向成为首期依赖。
 
 ---
 
@@ -556,16 +569,19 @@ except _ChatRunCancelled as cancelled:
 
 ---
 
-## 12. 首期结束条件
+## 12. 实施完成后的边界
 
-满足 §11 后，本次取消机制重构即完成。以下现象不阻塞首期结束：
+§11 已满足，本次取消机制重构完成。SSE adapter 现在会在客户端断开或 ASGI 取消时请求停止
+generation，先取消并 join 自己创建的 pull task，再关闭 `chat_stream()`；Alice、Agent loop、
+Worker 与 RunExecutor 的清理异常也不会替换正在传播的 `CancelledError`。
 
-- SSE 断开仍会结束当前 `chat_stream()` 所拥有的生命周期；
-- 外层 SSE generator 因背压暂停在 `yield` 时，Alice 取消可能延迟到下一次 pull 或 close；
+以下事项仍不属于本次最小闭环：
+
+- Chat Run 生命周期仍由当前请求中的 `chat_stream()` 拥有，没有独立 Job、断线重连或后台状态查询；
 - 取消时少量尚未离开 Alice 内部队列的 event 可能不再送达；
 - cancelled `done` 与前端 partial text 的长期契约尚未版本化；
 - RuntimeEvent 仍存在历史事件粒度和时序差异；
-- Prepare 尚未使用资源租约；
+- Prepare 未使用资源租约，且在现有短时、不可取消语义下默认不需要；
 - Gateway command 尚未建立通用提交屏障。
 
-这些是已知后续候选，不是最小取消闭环的缺陷回补清单。
+这些是后续设计的按需候选，不是已完成取消闭环的缺陷回补清单。

--- a/docs/contracts/error-model.md
+++ b/docs/contracts/error-model.md
@@ -126,7 +126,7 @@ warning 的核心语义是“主要成果仍然成立”。例如 READ 多个 al
 
 `MTPResponse.content` 只承载成功业务内容；error 和 warning 分别使用结构化字段，不能先拼进 content 再要求调用方解析。KoakumaRuntime 的 `_route_and_execute()` 是普通 verb handler 异常转换为 `MTPErrorInfo` 的集中边界，取消和 CALL suspend 等控制流继续按专用语义处理。
 
-`MTPFormatter` 是普通 Agent-facing MTP 回填文本的唯一构造点：它根据 language 渲染 code/severity/message/warnings，并排除内部 cause。`response_content` 只是业务 payload，不等于完整回填；需要写回模型历史时应使用运行结果的 `formatted_response`。CALL 不经过旧的通用 IPC 文本拼接，而由 `RunExecutor`/`CallCoordinator` 消费 `MTPCallRequest`；`CallContextProvider` 在编排边界解析 Profile 和共享上下文。Executor 递归等待被调用 frame，CallCoordinator 先 finalize callee，再由 `call_response.py` 把最终 `FrameExecutionResult` 单向映射为一个 `MTPCallResponse`，最后交给 `AgentRuntime.apply_call_response()` 恢复 caller frame。response 提交早于可等待的结束事件发送；取消 response 同样 exactly-once 回填，随后由 `CancelRun` 终止 run。`SUSPENDED` 是非终态控制流，不参与错误映射。
+`MTPFormatter` 是普通 Agent-facing MTP 回填文本的唯一构造点：它根据 language 渲染 code/severity/message/warnings，并排除内部 cause。`response_content` 只是业务 payload，不等于完整回填；需要写回模型历史时应使用运行结果的 `formatted_response`。CALL 不经过旧的通用 IPC 文本拼接，而由 `RunExecutor`/`CallCoordinator` 消费 `MTPCallRequest`；`CallContextProvider` 在编排边界解析 Profile 和共享上下文。Executor 递归等待被调用 frame，CallCoordinator 先 finalize callee，再由 `call_response.py` 把最终 `FrameExecutionResult` 单向映射为一个 `MTPCallResponse`，最后交给 `AgentRuntime.apply_call_response()` 恢复 caller frame。response 提交早于可等待的结束事件发送；内部已结算的 `CANCELLED` 结果可以映射为 CALL response，但外层 task cancellation 不回填伪造 response，也不终止 caller 重入流程。`SUSPENDED` 是非终态控制流，不参与错误映射。
 
 当前 formatter 尚未为所有业务 content/reply/warning 提供统一 XML escaping，因此错误结构稳定不等于任意 payload 都是严格合法 XML。这个限制应在 formatter 层修复，不能由各 verb handler 各自发明转义规则。
 
@@ -138,7 +138,7 @@ warning 的核心语义是“主要成果仍然成立”。例如 READ 多个 al
 
 ### 4.2 Gateway
 
-- `GatewayCancelledError`：调用方 cancel event 已触发；
+- 外层 task cancellation：由 Chat application 取消 Gateway child task，原生 `asyncio.CancelledError` 直接传播；
 - `GatewayTimeoutError`：总 deadline 无法形成完整终态；
 - workflow 内部不变量或 step 投影失败：保留原异常并发布 failed RuntimeEvent。
 

--- a/docs/contracts/mtp.md
+++ b/docs/contracts/mtp.md
@@ -194,7 +194,7 @@ Localized message
 
 Warning 放在 `<warnings><warning>...</warning></warnings>` 中。`pending_alias`、`call_request` 和内部 cause 不序列化到普通 Agent 响应正文，由运行时结构化消费。
 
-CALL 取消使用 `<mtp_response status="cancelled">` exactly-once 回填本地化的取消文案，不伪装为空 success，也不需要构造 error code。全局 run 取消时，回填完成后返回 `CancelRun`，caller 不会据此重入并继续生成。
+内部 callee 自然产生 `CANCELLED` 时，CALL 可以使用 `<mtp_response status="cancelled">` exactly-once 回填本地化结果；这不是 Chat-level stop 协议。全局 run 被 task cancellation 取消时，CallCoordinator 只清理活跃 record 和 callee frame，不伪造 caller response，CancelledError 沿递归调用栈传播。
 
 当前 formatter 会把业务 `content`、reply 和 warning 文本直接嵌入 XML 容器，尚未对所有内容执行统一 XML escaping。若文本自身包含 `<`、`>` 或 `&`，Agent 可见结果可能不是严格可解析 XML；调用方当前应把它视为结构化文本信封，而不是承诺任意 payload 都能通过 XML parser。补齐 escaping 时必须同时验证代码片段与既有 prompt 行为。
 

--- a/docs/contracts/routes-and-events.md
+++ b/docs/contracts/routes-and-events.md
@@ -12,7 +12,7 @@ code_paths:
 related_contracts:
   - docs/contracts/subsystem-contracts.md
   - docs/contracts/error-model.md
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-05
 ---
 
 # 公开路由与事件
@@ -61,7 +61,7 @@ Pub/Sub 是通知语义，不能用于要求调用方获得确定返回值的工
 
 | Route | Handler | 输入摘要 | 输出 |
 |:---|:---|:---|:---|
-| `gateway.public.process` | `GatewayService.process` | message、Identity、ingress mode、可选 cancel/timeout | `GatewayProcessResult` |
+| `gateway.public.process` | `GatewayService.process` | message、Identity、ingress mode、可选 `request_timeout_ms` | `GatewayProcessResult` |
 
 ### 2.2 Patchouli Chat / Retrieval
 

--- a/docs/contracts/routes-and-events.md
+++ b/docs/contracts/routes-and-events.md
@@ -107,10 +107,10 @@ Pub/Sub 是通知语义，不能用于要求调用方获得确定返回值的工
 
 | Route | Handler | 输入摘要 | 输出 |
 |:---|:---|:---|:---|
-| `alice.public.run_agent` | `AgentRunService.run_agent` | `AgentRunContext`、generation options、cancel event | `AgentRunResult` |
-| `alice.public.run_agent_stream` | `AgentRunService.run_agent_stream` 适配器 | 同上 | async generator 对象 |
+| `alice.public.run_agent` | `AgentRunService.run_agent` | `AgentRunContext`、generation options | `AgentRunResult` |
+| `alice.public.run_agent_stream` | `AgentRunService.run_agent_stream` 适配器 | `AgentRunContext`、generation options | async generator 对象 |
 
-流式 route 返回的是当前 Agent run 的交互输出流。兼容事件名保持为 `token`、`mtp_start`、`mtp_result`、`sub_agent_start`、`sub_agent_end` 和 `done`；每个事件携带 run-local `stream_sequence`，frame/CALL 事件还携带 `agent_run_id/frame_id/action_id` 等关联字段。这条流使用有界队列和背压，调用方提前断开会取消当前 run，因此它属于请求执行协议的一部分，不是 RuntimeEvent 观测 SSE 的别名。
+流式 route 返回的是当前 Agent run 的交互输出流。兼容事件名保持为 `token`、`mtp_start`、`mtp_result`、`sub_agent_start`、`sub_agent_end` 和 `done`；每个事件携带 run-local `stream_sequence`，frame/CALL 事件还携带 `agent_run_id/frame_id/action_id` 等关联字段。这条流使用有界队列和背压，调用方提前断开会取消当前 runner 并沿 task cancellation 收尾，因此它属于请求执行协议的一部分，不是 RuntimeEvent 观测 SSE 的别名。
 
 ## 3. 全局业务事件
 

--- a/docs/contracts/subsystem-contracts.md
+++ b/docs/contracts/subsystem-contracts.md
@@ -48,7 +48,6 @@ process(
     *,
     identity: Identity,
     ingress_mode: GatewayIngressMode,
-    cancel_event: asyncio.Event | None = None,
     request_timeout_ms: int | None = None,
 ) -> GatewayProcessResult
 ```
@@ -170,7 +169,6 @@ Memory 与 Topic 的身份可见性由 Patchouli 执行，调用方不能仅凭�
 run_agent(
     agent_run_context: AgentRunContext,
     generation_options: dict[str, Any] | None = None,
-    cancel_event: asyncio.Event | None = None,
 ) -> AgentRunResult
 ```
 
@@ -183,11 +181,11 @@ run_agent(
 - `materialize_tasks`：本 run 产生的不可变物化请求；
 - `model_used`：注册表解析出的展示名，空字符串表示未解析。
 
-这个结果是 Alice 对一次执行的完整事实声明，而不是已经提交的长期记忆。System 据此决定是否进入 finalize，Patchouli 再归约其中的 turn events 和 materialize tasks；任何一方都不能仅凭流中的部分文本推断 run 已经完成。
+这个结果是 Alice 对一次执行的完整事实声明，而不是已经提交的长期记忆。Chat application 通过拥有的 task 控制用户 stop，Alice 只沿 await 传播原生 `asyncio.CancelledError`；System 据此决定是否进入 finalize，Patchouli 再归约其中的 turn events 和 materialize tasks；任何一方都不能仅凭流中的部分文本推断 run 已经完成。
 
 ### 4.2 流式运行
 
-`run_agent_stream()` 接收相同输入，经全局 RPC 返回 async generator。流中包含增量事件，最终必须给 System 提供完整 `AgentRunResult`；只有拿到正常完成的最终结果才能进入 Patchouli finalize。
+`run_agent_stream()` 接收相同输入，经全局 RPC 返回 async generator。流中包含增量事件，消费者关闭时由 Alice 取消并 join 自己创建的 runner；最终必须给 System 提供完整 `AgentRunResult`，只有拿到正常完成的最终结果才能进入 Patchouli finalize。
 
 ### 4.3 Alice 不变量
 

--- a/docs/gateway/README.md
+++ b/docs/gateway/README.md
@@ -10,7 +10,7 @@ related_contracts:
   - docs/contracts/subsystem-contracts.md
   - docs/contracts/routes-and-events.md
   - docs/architecture/boundaries.md
-last_reviewed: 2026-07-29
+last_reviewed: 2026-08-05
 ---
 
 # Gateway
@@ -37,7 +37,7 @@ Gateway 当前负责：
 - 读取候选话题快照并选择已有话题或 `NEW_TOPIC`；
 - 对路由后的用户输入生成意图、query rewrite、关键词、记忆写入信号和检索计划；
 - 对可恢复的上下文或模型能力失败应用局部保守降级；
-- 处理整次请求的 deadline、调用方取消和 RuntimeEvent 观测；
+- 处理整次请求的 deadline 与 RuntimeEvent 观测；外层 task cancellation 原样传播，不建立 Gateway 私有取消协议；
 - 只通过 `gateway.public.process` 暴露稳定公共结果。
 
 Gateway 不负责：

--- a/docs/gateway/workflow.md
+++ b/docs/gateway/workflow.md
@@ -125,7 +125,7 @@ GatewayDecisionOutcome
 
 请求控制遵循两个原则：取消优先传播，deadline 限制整条链路。
 
-`cancel_event` 在 Step 开始前和能力调用等待期间都会检查。取消发生时，当前 invocation task 被取消并等待收尾，workflow 抛出 `GatewayCancelledError`。取消不是能力退化，因此不能转为本地 fallback 或普通 decision。
+Gateway 不接收 Chat Run 的取消句柄，也不轮询取消状态。Chat application 在进入 Gateway 阶段时创建 child task；用户 stop 直接取消这个 task，原生 `asyncio.CancelledError` 沿当前 await 传播。取消不是能力退化，因此不能转为本地 fallback 或普通 decision；request deadline 和 Step timeout 仍由 workflow 自己负责，并继续使用现有 fallback 规则。
 
 请求 deadline 从 workflow 开始时计算。每个 Step 的实际等待时间是“Step timeout”与“整次请求剩余时间”的较小值。若整次 deadline 在某个可降级 Step 中耗尽，该 Step 先提交 fallback，后续带 fallback 的 Step 不再调用能力，而是继续提交保守默认值，直到形成完整 decision；若当前 Step 没有 fallback，则抛出 `GatewayTimeoutError`。
 

--- a/docs/gateway/workflow.md
+++ b/docs/gateway/workflow.md
@@ -11,7 +11,7 @@ related_contracts:
   - docs/contracts/subsystem-contracts.md
   - docs/contracts/routes-and-events.md
   - docs/contracts/error-model.md
-last_reviewed: 2026-07-29
+last_reviewed: 2026-08-05
 ---
 
 # Gateway 固定工作流
@@ -40,7 +40,7 @@ GatewayWorkflow
 
 `GatewayWorkflow` 是请求级执行协调者，`GatewayExecutionState` 只由它持有。Engine、Provider、Resolver 和 Dispatcher 可以替换，但不能改变公共终态结构；拓扑若发生变化，应显式修改 `build_gateway_workflow()` 和当前文档，而不是让某个 Engine 私下跳转到另一步。
 
-`GatewayService.process()` 会先收敛请求 timeout：调用方可以给出更短的 `request_timeout_ms`，但不能用它扩大配置中的 `default_request_timeout_ms`。随后 Service 将消息、`Identity`、入口模式、取消信号和有效 deadline 交给 workflow。
+`GatewayService.process()` 会先收敛请求 timeout：调用方可以给出更短的 `request_timeout_ms`，但不能用它扩大配置中的 `default_request_timeout_ms`。随后 Service 将消息、`Identity`、入口模式和有效 deadline 交给 workflow；Gateway 不接收 Chat Run 控制对象或取消参数。
 
 ## 2. 当前固定拓扑
 
@@ -147,7 +147,7 @@ Gateway 不接收 Chat Run 的取消句柄，也不轮询取消状态。Chat app
 
 ## 7. 观测不是控制面
 
-Workflow 发布 started、step completed、completed、cancelled 和 failed RuntimeEvent。Step 事件会记录 `step_id`、序号、耗时、是否 fallback 和原因；终态事件记录 outcome kind 与总耗时。
+Workflow 发布 started、step completed、completed 和 failed RuntimeEvent。Step 事件会记录 `step_id`、序号、耗时、是否 fallback 和原因；终态事件记录 outcome kind 与总耗时。原生 task cancellation 直接离开 Gateway，不发布 `gateway.workflow.cancelled`，也不伪装成 failed 观测。
 
 RuntimeEvent sink 失败不得改变 Gateway 结果。观测字段也不进入公共 outcome。关于 RuntimeEvent 的统一边界见 [System 可观测性](../system/observability.md)。
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -12,7 +12,6 @@ last_reviewed: 2026-08-05
 
 当前计划：
 
-- [Chat Run 取消重构最小闭环](./chat-run-cancellation-unified.md)：当前实施依据；仅以 `Task.cancel()` 跑通 `/chat/stop` 对 Gateway 与 Alice agent run 的取消，移除阶段内部私有取消协议，prepare 延迟响应 stop，finalize 进入后不再接受 stop。
 - [Chat Run 取消与生命周期后续设计](./chat-run-cancellation-future.md)：不阻塞最小闭环的独立候选集合，包括 SSE 所有权解耦、事件发布收敛、前端 `final_text` 契约等；`PreparedRunLease` 无限期延后，并保留删除该设计的可能。
 - [数据模型可变性治理](./data-model-mutability-governance.md)：未排期的项目级模型角色、所有权与边界投影治理。
 - [RuntimeEvent 生产端发布抽象重构](./runtime-event-publishing-refactor.md)：统一 Publisher、领域 emitter、payload 安全与生产端 best-effort 边界，当前未实现。

--- a/docs/plans/chat-run-cancellation-future.md
+++ b/docs/plans/chat-run-cancellation-future.md
@@ -12,7 +12,7 @@ code_paths:
   - src/hivememory/server/routers/chat.py
   - frontend/src/stores/chat/
 related_docs:
-  - docs/plans/chat-run-cancellation-unified.md
+  - docs/archive/plans/chat-run-cancellation-unified.md
   - docs/plans/runtime-event-publishing-refactor.md
   - docs/plans/cross-subsystem-idempotency-and-retry.md
   - docs/system/observability.md
@@ -25,9 +25,9 @@ last_reviewed: 2026-08-05
 ## 1. 文档定位
 
 本文档保存从取消重构中拆出的后续候选设计。它不是当前实施依据，也不是
-[Chat Run 取消重构最小闭环](./chat-run-cancellation-unified.md) 的前置依赖。
+[已归档的 Chat Run 取消重构最小闭环](../archive/plans/chat-run-cancellation-unified.md) 的前置依赖。
 
-最小闭环完成后，只有在产品需求、运行指标或真实故障证明有必要时，才按本文各节的
+最小闭环已完成。只有在产品需求、运行指标或真实故障证明有必要时，才按本文各节的
 独立启用条件立项。不得以“架构最终会需要”为理由一次性实施全部内容。
 
 本文覆盖：

--- a/docs/plans/identity-isolation-and-execution-safety.md
+++ b/docs/plans/identity-isolation-and-execution-safety.md
@@ -17,7 +17,7 @@ related_docs:
   - docs/alice/mtp-runtime.md
   - docs/alice/orchestration.md
   - docs/todo/frontend-identity-ownership.md
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-05
 ---
 
 # 身份隔离与执行安全计划
@@ -33,7 +33,7 @@ HiveMemory 已经把 Identity、MemoryVisibility、MTP permission、Agent Profil
 | Memory visibility | MemoryAtom 有 user/team/session/visibility，Patchouli 是可见性所有者 | 某些别名 L0/L1 cache 命中不会再次按调用 Identity 校验 |
 | PendingAtom | atom 保存 identity，Alice 通过 alias/intent 解析 | 进程级 cache/store 与并发 run 共享，跨用户隔离尚未完全成立 |
 | Agent Profile | Profile 作为 MemoryAtom，通过 retrieval/alias 发现 | alias cache 进程级、失效不完整；显式 Profile 加载失败与未指定 Profile 的 Omni-Doll fallback 语义混淆 |
-| Agent run/frame | `ExecutionFrame`、`RunSession`、frame policy 与 `AgentRunStreamAdapter` | frame registry、CALL record、取消信号、输出队列和流序号已按 run 隔离；跨用户身份与缓存隔离仍待验证 |
+| Agent run/frame | `ExecutionFrame`、`RunSession`、frame policy、Chat phase task 与 `AgentRunStreamAdapter` | frame registry/CALL record、Chat 可中断阶段 task、Alice runner、输出队列和流序号均按 run 隔离；跨用户身份与缓存隔离仍待验证 |
 | MTP permission | Prompt 与 Koakuma runtime 有双层权限设计 | prompt 教学不是硬安全保证，部分身份/权限重新校验仍需收紧 |
 | MTP READ/RUN | READ 可访问记忆，RUN 可执行 memory code | RUN 没有强沙箱、资源限制、可信资产分级或强制审批边界 |
 | Frontend identity | 前端已有默认 user id 和待办的 identity store 方向 | UI 字段不是认证/授权边界，多个请求可能使用不同默认身份；切换时 cache/stream 清理不完整 |

--- a/docs/plans/identity-isolation-and-execution-safety.md
+++ b/docs/plans/identity-isolation-and-execution-safety.md
@@ -114,7 +114,7 @@ MTP RUN 应将“可读取的 Memory”与“可执行的 Memory”分开：
 
 ### Phase S2：Run-local 执行隔离（基础已完成）
 
-1. 已完成：以 `RunSession` 替代共享 FrameScheduler stack，将 cancel token、frame registry 和 CALL record 收敛为 run-local 状态；流式输出队列与流序号由每次 run 独占的 `AgentRunStreamAdapter/QueueAgentRunOutput` 持有，运行预算由 frame policy 持有；
+1. 已完成：以 `RunSession` 替代共享 FrameScheduler stack，将 frame registry 和 CALL record 收敛为 run-local 状态；Chat application 在上层持有可取消阶段 task，流式输出队列与流序号由每次 run 独占的 `AgentRunStreamAdapter/QueueAgentRunOutput` 持有，运行预算由 frame policy 持有；
 2. 继续验证并发 Agent run 的 CALL、READ、WRITE、citation、PendingAtom 和 cancel 不会跨用户或 workspace 交叉；
 3. 已完成：被调用 frame 继承 caller Identity，CALL 权限由 `FrameExecutionPolicy` 和 Profile capability 硬检查，不再以 depth 作为控制依据；
 4. 明确恢复/重试时不能复用已经失效的授权快照。

--- a/docs/system/application-services.md
+++ b/docs/system/application-services.md
@@ -10,7 +10,7 @@ related_contracts:
   - docs/contracts/subsystem-contracts.md
   - docs/contracts/routes-and-events.md
   - docs/contracts/error-model.md
-last_reviewed: 2026-07-29
+last_reviewed: 2026-08-05
 ---
 
 # System 应用服务
@@ -89,7 +89,7 @@ generation_id
        done(completed + memory_task_ids + pool_topics)
 ```
 
-流式生成必须收到 Alice 的最终 `done` 才能构造 `AgentRunResult`。若流在没有终态事件时结束，服务按协议错误处理；客户端提前关闭流则将 run 标记为 `cancelled`，关闭 Alice 子流，并对尚未 finalize 的 prepared run 执行 cleanup。
+流式生成必须收到 Alice 的最终 `done` 才能构造 `AgentRunResult`。若流在没有终态事件时结束，服务按协议错误处理；客户端提前关闭时，SSE adapter 请求停止当前 generation，先取消并 join 自己创建的 stream-pull task，再关闭 Chat generator。`chat_stream()` 随后关闭 Alice 子流，并对尚未 finalize 的 prepared run 执行 cleanup。
 
 流式 `done`、`command_result` 和 `error` 是 transport 可消费的事件，不是新的跨子系统业务契约；它们的来源和调用顺序仍由本服务和 Contracts 共同约束。
 
@@ -98,11 +98,14 @@ generation_id
 `ChatGenerationRunRegistry` 是 System 应用层拥有的进程内控制表。每条 run 有：
 
 - `generation_id`；
-- `asyncio.Event` 取消信号；
-- `created/preparing/streaming/finalizing/completed/cancelling/cancelled/failed` 状态；
-- 首次取消原因。
+- `phase`：`created/gateway/prepare/alice/finalize/terminal`；
+- `outcome`：`running/stop_requested/cancelled/completed/failed`；
+- 首次接受的 `stop_reason`；
+- 仅在 Gateway 或 Alice 阶段存在的 `active_task` 身份引用。
 
-`cancel_generation()` 是幂等的：不存在返回 `not_found`，已完成或已失败的 run 不再改变业务终态，仍然可以返回当前状态。取消信号通过 Gateway、Alice 和流式清理边界传递，不由 RuntimeEvent 或客户端断连事件直接替代。
+Registry 不保存 `Event`、Token 或 waiter。`cancel_generation()` 查找 run 后同步调用 `request_stop()`：不存在返回 `not_found`；首次 stop 固定 reason；重复 stop 返回同一判定且不重复取消 task。Gateway 与 Alice 阶段会取消当前 `active_task`；Prepare 只记录 stop，正常返回后由应用服务终止后续阶段；阶段交接窗口只记录 stop，下一阶段不会启动；Finalize 与 Terminal 拒绝 stop。`active_task` 只表达当前可中断阶段的 task 身份，不是另一份取消状态。
+
+用户 stop 在 `chat_service.py` 内被翻译为私有 `_ChatRunCancelled` 分支，下游只传播原生 `asyncio.CancelledError`。`_run_interruptible()` 同时区分“stop 取消 child task”和“Chat owner 被 ASGI/shutdown 取消”，后者必须原样向上传播。资源所有者在 unwind 中关闭自己创建的 stream、runner 与 provider response；收尾异常只记录日志，不能替换正在传播的 `CancelledError`。
 
 当前 registry 是进程内短期控制状态，不是可恢复 Job。进程重启后不能据此恢复 run；长期 Job 生命周期属于后续 Runtime Job Queue 计划。
 
@@ -123,7 +126,7 @@ generation_id
 ## 6. 错误、观测与 cleanup
 
 - 业务拒绝或资源不存在应使用服务定义的稳定结果/异常；
-- Gateway cancel/timeout 和 Alice 取消不应被包装成普通 success；
+- Gateway/Alice 的 task cancellation 不应被包装成普通 success 或 failed；Gateway timeout 仍按自己的 deadline/fallback 契约处理；
 - `RuntimeEventSink` 只记录 chat run、状态和失败，不改变返回值；
 - cleanup 是 prepare 失败后的有限补偿，不是跨子系统 rollback；
 - 应用服务捕获的错误应保留原始因果，不能通过“空列表/空话题”掩盖 route 缺失或契约违约。
@@ -144,7 +147,9 @@ generation_id
 ## 8. 验证入口
 
 - `tests/unit/system/application/test_gateway_chat_flow.py`
+- `tests/unit/system/test_chat_run_control_contract.py`
 - `tests/unit/system/test_cancel_hardening.py`
+- `tests/unit/server/routers/test_chat.py`
 - `tests/unit/system/application/test_api_services.py`
 - `tests/unit/system/application/test_memory_service.py`
 - `tests/unit/system/application/test_memory_task_service.py`

--- a/docs/system/runtime-and-bus.md
+++ b/docs/system/runtime-and-bus.md
@@ -12,12 +12,12 @@ related_contracts:
   - docs/contracts/routes-and-events.md
   - docs/contracts/error-model.md
   - docs/architecture/boundaries.md
-last_reviewed: 2026-07-29
+last_reviewed: 2026-08-05
 ---
 
 # System 运行时与总线
 
-System 的运行时基础设施解决的是“如何让多个所有者交接”，不是“把所有行为放进一个中央控制器”。GlobalSystemBus 负责跨子系统 public route，GlobalMaintenanceScheduler 负责系统级维护 tick，Runtime control 负责前台用例的取消句柄，RuntimeEventSink 负责观测旁路。
+System 的运行时基础设施解决的是“如何让多个所有者交接”，不是“把所有行为放进一个中央控制器”。GlobalSystemBus 负责跨子系统 public route，GlobalMaintenanceScheduler 负责系统级维护 tick，Runtime control 负责前台用例的阶段与停止控制，RuntimeEventSink 负责观测旁路。
 
 这些组件共享进程和 event loop，但不共享业务状态。把它们混成一个大总线会让观测、维护和业务 RPC 互相影响，也会让任何订阅者都看起来像新的状态所有者。
 

--- a/docs/system/runtime-and-bus.md
+++ b/docs/system/runtime-and-bus.md
@@ -80,15 +80,20 @@ jitter_seconds     -> 可选启动抖动
 
 ## 3. Runtime control
 
-`ChatGenerationRunRegistry` 是 System 应用层的前台控制表，保存 generation ID、取消 event、状态和取消原因。它只服务进程内 chat run：
+`ChatGenerationRunRegistry` 是 System 应用层的前台控制表，保存 generation ID、当前阶段、状态、取消原因和当前阶段的 task 引用。它只服务进程内 chat run：
 
 ```text
 client cancel
   -> registry.cancel(generation_id)
-  -> cancel_event.set()
-  -> Gateway/Alice 检查并终止当前能力
+  -> ChatGenerationRun.request_stop()
+  -> 取消 Gateway/Alice 阶段 child task
   -> ChatApplicationService 决定取消 done 与 prepared cleanup
 ```
+
+Gateway、Alice request 和 stream pull 是 Chat application 创建并等待的阶段 task；`request_stop()`
+同步记录首次 stop reason，并且只调用一次 `Task.cancel()`。Prepare 没有可取消 task，停止只记账，
+返回后由 application 检查；Finalize 已经开始后拒绝 stop。跨子系统的取消传播使用原生
+`asyncio.CancelledError`，用户 stop 只在 Chat application 边界翻译为取消结果。
 
 该 registry 不提供持久化恢复、跨进程广播或历史查询。不要把它与后续 Runtime Job Queue 的长期任务状态混为一谈。
 
@@ -104,7 +109,7 @@ client cancel
 System application service -> GlobalSystemBus RPC -> subsystem owner
 Subsystem maintenance task -> GlobalMaintenanceScheduler callback
 Any operation -> RuntimeEventSink (best-effort observation)
-Chat cancel -> RuntimeControlRegistry -> current capability
+Chat cancel -> ChatGenerationRunRegistry -> current phase task
 ```
 
 禁止：

--- a/src/hivememory/agent_runtime/execution/loop.py
+++ b/src/hivememory/agent_runtime/execution/loop.py
@@ -71,14 +71,12 @@ class AgentLoopExecutor:
         frame: ExecutionFrame,
         generation_options: dict[str, Any] | None,
         sink: FrameOutputSink,
-        cancel_event: asyncio.Event | None,
     ) -> GenerationResult | FrameExecutionResult:
         """执行一轮 LLM 生成：按 sink 是否输出 token 选择完整 / 流式路径。"""
         if not sink.streams_tokens:
             try:
                 return await self.worker_agent.generate_async(
                     frame.working_history,
-                    cancel_event=cancel_event,
                     **(generation_options or {}),
                 )
             except asyncio.CancelledError:
@@ -93,7 +91,6 @@ class AgentLoopExecutor:
         result: GenerationResult | None = None
         chunks = self.worker_agent.generate_stream(
             frame.working_history,
-            cancel_event=cancel_event,
             **(generation_options or {}),
         ).__aiter__()
         while True:
@@ -116,8 +113,6 @@ class AgentLoopExecutor:
                 await sink.send(TokenDelta(content=chunk.delta))
         if result is not None:
             return result
-        if cancel_event is not None and cancel_event.is_set():
-            return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
         return FrameExecutionResult(
             status=FrameExecutionStatus.FAILED,
             error=RuntimeError("Streaming generation ended without a final result."),
@@ -129,7 +124,6 @@ class AgentLoopExecutor:
         max_iterations: int,
         generation_options: dict[str, Any] | None = None,
         output_sink: FrameOutputSink | None = None,
-        cancel_event: asyncio.Event | None = None,
     ) -> FrameExecutionResult:
         """
         执行单个帧的循环，直到自然收敛、命中 CALL 或进入其他明确终态。
@@ -144,24 +138,15 @@ class AgentLoopExecutor:
         sink = output_sink or NullFrameOutputSink()
 
         while p.iteration < max_iterations:
-            if cancel_event is not None and cancel_event.is_set():
-                logger.info("Generation cancelled by user")
-                return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
-
             p.iteration += 1
 
             result = await self._generate_turn(
                 frame,
                 generation_options,
                 sink,
-                cancel_event,
             )
             if isinstance(result, FrameExecutionResult):
                 return result
-
-            if result.finish_reason == "cancelled":
-                logger.info("Generation cancelled by user")
-                return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
 
             if not result.was_mtp_interrupted:
                 p.text_segments.append(result.text)
@@ -200,22 +185,10 @@ class AgentLoopExecutor:
                 runtime_scope=frame.runtime_scope.with_action(action_id),
                 execution_policy=frame.execution_policy,
             )
-            if cancel_event is not None and cancel_event.is_set():
-                logger.info("Generation cancelled before MTP execution")
-                return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
-
             mtp_result = await self._mtp_executor.intercept_and_execute(
                 result.text,
                 context=mtp_context,
-                cancel_event=cancel_event,
             )
-            if cancel_event is not None and cancel_event.is_set():
-                logger.info("Generation cancelled after MTP execution")
-                return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
-
-            if mtp_result is not None and mtp_result.response_status == "cancelled":
-                logger.info("MTP execution cancelled")
-                return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
 
             if mtp_result is not None and mtp_result.command:
                 verb_hint = mtp_result.command.verb.value
@@ -343,8 +316,6 @@ class AgentLoopExecutor:
             )
             p.sequence += 1
 
-        if cancel_event is not None and cancel_event.is_set():
-            return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
         return FrameExecutionResult(status=FrameExecutionStatus.BUDGET_EXHAUSTED)
 
     def _extract_command_info(self, command, raw_hint):

--- a/src/hivememory/agent_runtime/execution/loop.py
+++ b/src/hivememory/agent_runtime/execution/loop.py
@@ -93,24 +93,36 @@ class AgentLoopExecutor:
             frame.working_history,
             **(generation_options or {}),
         ).__aiter__()
-        while True:
-            try:
-                chunk = await anext(chunks)
-            except StopAsyncIteration:
-                break
-            except asyncio.CancelledError:
-                raise
-            except Exception as error:
-                logger.error("Streaming frame generation failed: %s", error, exc_info=True)
-                return FrameExecutionResult(
-                    status=FrameExecutionStatus.FAILED,
-                    error=error,
-                )
-            if chunk.is_final:
-                result = chunk.result
-                break
-            if not chunk.mtp_detected and chunk.delta:
-                await sink.send(TokenDelta(content=chunk.delta))
+
+        try:
+            while True:
+                try:
+                    chunk = await anext(chunks)
+                except StopAsyncIteration:
+                    break
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    logger.error("Streaming frame generation failed: %s", error, exc_info=True)
+                    return FrameExecutionResult(
+                        status=FrameExecutionStatus.FAILED,
+                        error=error,
+                    )
+                if chunk.is_final:
+                    result = chunk.result
+                    break
+                if not chunk.mtp_detected and chunk.delta:
+                    await sink.send(TokenDelta(content=chunk.delta))
+        finally:
+            close = getattr(chunks, "aclose", None)
+            if callable(close):
+                try:
+                    await close()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.warning("关闭 Worker stream 失败", exc_info=True)
+
         if result is not None:
             return result
         return FrameExecutionResult(

--- a/src/hivememory/agent_runtime/execution/worker.py
+++ b/src/hivememory/agent_runtime/execution/worker.py
@@ -1,42 +1,21 @@
 """
-Worker Agent Service - Agent Runtime 的无状态 LLM 文本生成服务
+Worker Agent Service - Agent Runtime 的无状态 LLM 文本生成服务。
 
-定位：单 frame 执行引擎的模型生成适配器，纯粹的文本生成器。
-职责：
-    - 封装 LLM API 调用 (via litellm)
-    - 使用 MTP Stop Sequence (⟫) 实现生成中断
-    - 检测 MTP 指令并返回结构化结果
-    - 不持有任何业务状态（由 AliceRuntime / AgentRuntime 调度）
-
-架构定位：
-    AgentRuntime 持有 WorkerAgentService，并由 AgentLoopExecutor 调用。
-    WorkerAgentService 不知道 MTP 协议的具体语义，只负责检测 ⟪ 定界符。
-
-    AliceSystem
-    ├── AliceRuntime
-    │   ├── KoakumaRuntime
-    │   ├── AgentRuntime
-    │   │   ├── AgentLoopExecutor
-    │   │   └── WorkerAgentService (LLM Engine)  ← 本模块
-    └── AgentRunService
-
-对应设计文档: MemoryToolProtocol.md Section 3.1 & 6.4
+Worker 只负责 LLM 调用、MTP stop sequence 和文本分段；取消由调用它的
+asyncio task 直接传播，不在本层维护额外的控制信号。
 """
 
-import asyncio
+from __future__ import annotations
+
+import inspect
 import logging
 from collections.abc import AsyncGenerator
-from contextlib import suppress
 from typing import Any
 
 import litellm
 
 from hivememory.agent_runtime.models import GenerationResult, StreamChunk
-from hivememory.core.constants import (
-    DEFAULT_MAX_TOKENS,
-    DEFAULT_TEMPERATURE,
-    DEFAULT_TOP_P,
-)
+from hivememory.core.constants import DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE, DEFAULT_TOP_P
 from hivememory.core.mtp.models import (
     MTP_LEFT_DELIMITER,
     MTP_RIGHT_DELIMITER,
@@ -47,38 +26,13 @@ logger = logging.getLogger(__name__)
 
 
 class WorkerAgentService:
-    """
-    无状态 LLM 文本生成服务
-
-    封装 litellm.acompletion() 调用，自动注入 MTP Stop Sequence，
-    并对返回结果进行 MTP 中断检测。
-
-    所有 LLM 参数（model、api_key、api_base 等）必须在每次调用时通过
-    generation_options 显式传入，不保存任何实例级配置。
-    model 缺失时立即抛出 ValueError，拒绝静默降级。
-
-    使用示例:
-        >>> service = WorkerAgentService()
-        >>> result = await service.generate_async(
-        ...     messages,
-        ...     model="deepseek/deepseek-chat",
-        ...     api_key="sk-...",
-        ... )
-    """
+    """无状态 LLM 文本生成服务。"""
 
     def __init__(self) -> None:
         logger.info("WorkerAgentService 初始化完成（无状态）")
 
     def _extract_runtime_params(self, kwargs: dict[str, Any]) -> dict[str, Any]:
-        """从 generation_options（kwargs）中提取本次 LLM 调用的运行时参数。
-
-        设计原则：
-        - model 是必填项，缺失即抛 ValueError。不允许隐式回落到"某个"模型——
-          用错模型比报错更糟糕。
-        - api_key / api_base 允许为 None：litellm 会从对应环境变量读取，
-          这是合法的密钥管理方式。
-        - temperature / max_tokens / top_p 缺失时使用项目级默认常量，不影响模型正确性。
-        """
+        """提取本次 LLM 调用的运行时参数。"""
         model = kwargs.pop("model", None)
         if not model:
             raise ValueError(
@@ -90,24 +44,18 @@ class WorkerAgentService:
         temperature = kwargs.pop("temperature", None)
         top_p = kwargs.pop("top_p", None)
         max_tokens = kwargs.pop("max_tokens", None)
-        # api_key / api_base 为 None 是合法状态（litellm 从环境变量读取）
-        api_key = kwargs.pop("api_key", None)
-        api_base = kwargs.pop("api_base", None)
-
-        # temperature / max_tokens / top_p 回落到项目级默认常量
-        params: dict[str, Any] = {
+        return {
             "model": model,
             "temperature": DEFAULT_TEMPERATURE if temperature is None else temperature,
             "max_tokens": DEFAULT_MAX_TOKENS if max_tokens is None else max_tokens,
             "top_p": DEFAULT_TOP_P if top_p is None else top_p,
-            "api_key": api_key,
-            "api_base": api_base,
+            "api_key": kwargs.pop("api_key", None),
+            "api_base": kwargs.pop("api_base", None),
         }
-        return params
 
     @staticmethod
     def _normalize_mtp_interrupted_text(text: str, last_open: int) -> str:
-        """为被 stop sequence 截断的 MTP 文本补全右定界符，供下游解析。"""
+        """为被 stop sequence 截断的 MTP 文本补全右定界符。"""
         if last_open == -1:
             return text
         mtp_fragment = text[last_open:]
@@ -118,62 +66,40 @@ class WorkerAgentService:
     async def generate_async(
         self,
         messages: list[dict[str, str]],
-        cancel_event: asyncio.Event | None = None,
         **kwargs,
     ) -> GenerationResult:
+        """执行一次完整 LLM 生成。"""
         runtime_params = self._extract_runtime_params(kwargs)
         try:
-            response = await self._completion_with_cancel(
-                cancel_event=cancel_event,
-                completion_kwargs=dict(
-                    model=runtime_params["model"],
-                    messages=messages,
-                    api_key=runtime_params["api_key"],
-                    api_base=runtime_params["api_base"],
-                    temperature=runtime_params["temperature"],
-                    max_tokens=runtime_params["max_tokens"],
-                    stop=[MTP_STOP_SEQUENCE],
-                    top_p=runtime_params["top_p"],
-                    **kwargs,
-                ),
+            response = await litellm.acompletion(
+                model=runtime_params["model"],
+                messages=messages,
+                api_key=runtime_params["api_key"],
+                api_base=runtime_params["api_base"],
+                temperature=runtime_params["temperature"],
+                max_tokens=runtime_params["max_tokens"],
+                stop=[MTP_STOP_SEQUENCE],
+                top_p=runtime_params["top_p"],
+                **kwargs,
             )
-        except Exception as e:
-            logger.error(f"LLM 异步生成失败: {e}")
+        except Exception as error:
+            logger.error("LLM 异步生成失败: %s", error)
             raise
-
-        if response is None:
-            return GenerationResult(
-                text="",
-                finish_reason="cancelled",
-                was_mtp_interrupted=False,
-                prefix_text="",
-                mtp_fragment="",
-                model_used=runtime_params["model"],
-            )
 
         text = response.choices[0].message.content or ""
         finish_reason = response.choices[0].finish_reason or "stop"
-
-        if cancel_event is not None and cancel_event.is_set():
-            text = ""
-            finish_reason = "cancelled"
-
         if hasattr(response, "usage") and response.usage:
             logger.info(
-                f"LLM 异步生成完成 (model={runtime_params['model']}, "
-                f"tokens={response.usage.total_tokens}, "
-                f"finish_reason={finish_reason})"
+                "LLM 异步生成完成 (model=%s, tokens=%s, finish_reason=%s)",
+                runtime_params["model"],
+                response.usage.total_tokens,
+                finish_reason,
             )
 
         last_open = text.rfind(MTP_LEFT_DELIMITER)
         was_mtp = finish_reason == "stop" and last_open != -1
-
         if was_mtp:
             text = self._normalize_mtp_interrupted_text(text, last_open)
-            logger.info(
-                f"MTP 中断检测: ⟪ 位于 offset={last_open}, "
-                f"prefix_len={last_open}, fragment_len={len(text) - last_open}"
-            )
 
         return GenerationResult(
             text=text,
@@ -184,55 +110,12 @@ class WorkerAgentService:
             model_used=runtime_params["model"],
         )
 
-    async def _completion_with_cancel(
-        self,
-        *,
-        cancel_event: asyncio.Event | None,
-        completion_kwargs: dict[str, Any],
-    ) -> Any:
-        """让 LLM 请求与 cancel_event 竞争；取消命中时主动取消 completion task。"""
-        completion_task = asyncio.create_task(litellm.acompletion(**completion_kwargs))
-        if cancel_event is None:
-            return await completion_task
-
-        cancel_task = asyncio.create_task(cancel_event.wait())
-        try:
-            done, _ = await asyncio.wait(
-                {completion_task, cancel_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            if cancel_task in done:
-                completion_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await completion_task
-                return None
-            return await completion_task
-        finally:
-            cancel_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await cancel_task
-
     async def generate_stream(
         self,
         messages: list[dict[str, str]],
-        cancel_event: asyncio.Event | None = None,
         **kwargs,
     ) -> AsyncGenerator[StreamChunk, None]:
-        """
-        流式 LLM 生成，逐 chunk yield
-
-        使用 litellm.acompletion(stream=True)，实时检测 MTP 定界符 ⟪。
-        - 检测到 ⟪ 之前：每个 chunk 作为 delta yield (mtp_detected=False)
-        - 检测到 ⟪ 之后：继续缓冲但不 yield delta (mtp_detected=True)
-        - 流结束时：yield is_final=True 的 StreamChunk，携带完整 GenerationResult
-
-        Args:
-            messages: OpenAI 格式的消息列表
-            **kwargs: 传递给 litellm 的额外参数
-
-        Yields:
-            StreamChunk: 流式 chunk
-        """
+        """流式生成文本，并在结束或取消时关闭底层 async iterator。"""
         runtime_params = self._extract_runtime_params(kwargs)
         try:
             response = await litellm.acompletion(
@@ -247,91 +130,91 @@ class WorkerAgentService:
                 stream=True,
                 **kwargs,
             )
-        except Exception as e:
-            logger.error(f"LLM 流式生成启动失败: {e}")
+        except Exception as error:
+            logger.error("LLM 流式生成启动失败: %s", error)
             raise
 
         full_text = ""
         mtp_detected = False
         finish_reason = "stop"
-        # 缓冲区：用于处理 ⟪ 可能跨 chunk 边界的情况
         pending = ""
         delimiter_tail = max(0, len(MTP_LEFT_DELIMITER) - 1)
 
-        async for chunk in response:
-            if cancel_event is not None and cancel_event.is_set():
-                logger.info("LLM 流式生成被用户取消")
-                finish_reason = "cancelled"
-                break
+        try:
+            async for chunk in response:
+                choice = chunk.choices[0] if chunk.choices else None
+                if choice is None:
+                    continue
 
-            choice = chunk.choices[0] if chunk.choices else None
-            if choice is None:
-                continue
+                delta_content = choice.delta.content or ""
+                if choice.finish_reason:
+                    finish_reason = choice.finish_reason
+                if not delta_content:
+                    continue
 
-            delta_content = choice.delta.content or ""
-            if choice.finish_reason:
-                finish_reason = choice.finish_reason
+                full_text += delta_content
+                if mtp_detected:
+                    continue
 
-            if not delta_content:
-                continue
-
-            full_text += delta_content
-
-            if not mtp_detected:
                 pending += delta_content
                 if MTP_LEFT_DELIMITER in pending:
                     mtp_detected = True
-                    idx = pending.index(MTP_LEFT_DELIMITER)
-                    # ⟪ 之前的文本作为最后一个正常 delta 推送
-                    before = pending[:idx]
+                    index = pending.index(MTP_LEFT_DELIMITER)
+                    before = pending[:index]
                     if before:
-                        yield StreamChunk(delta=before, full_text=full_text, mtp_detected=False)
-                    # ⟪ 及之后的内容不推送，标记 mtp_detected
+                        yield StreamChunk(
+                            delta=before,
+                            full_text=full_text,
+                            mtp_detected=False,
+                        )
                     yield StreamChunk(delta="", full_text=full_text, mtp_detected=True)
                     pending = ""
+                    continue
+
+                if delimiter_tail == 0:
+                    emit_text = pending
+                    pending = ""
+                elif len(pending) > delimiter_tail:
+                    emit_text = pending[:-delimiter_tail]
+                    pending = pending[-delimiter_tail:]
                 else:
-                    if delimiter_tail == 0:
-                        emit_text = pending
-                        pending = ""
-                    elif len(pending) > delimiter_tail:
-                        emit_text = pending[:-delimiter_tail]
-                        pending = pending[-delimiter_tail:]
-                    else:
-                        emit_text = ""
-                    if emit_text:
-                        yield StreamChunk(delta=emit_text, full_text=full_text, mtp_detected=False)
-            # mtp_detected=True 后不再 yield 中间 chunk，静默缓冲
+                    emit_text = ""
+                if emit_text:
+                    yield StreamChunk(
+                        delta=emit_text,
+                        full_text=full_text,
+                        mtp_detected=False,
+                    )
 
-        if not mtp_detected and pending:
-            yield StreamChunk(delta=pending, full_text=full_text, mtp_detected=False)
+            if not mtp_detected and pending:
+                yield StreamChunk(delta=pending, full_text=full_text, mtp_detected=False)
 
-        # 流结束，构建最终 GenerationResult
-        last_open = full_text.rfind(MTP_LEFT_DELIMITER)
-        was_mtp = finish_reason == "stop" and last_open != -1
+            last_open = full_text.rfind(MTP_LEFT_DELIMITER)
+            was_mtp = finish_reason == "stop" and last_open != -1
+            if was_mtp:
+                full_text = self._normalize_mtp_interrupted_text(full_text, last_open)
 
-        if was_mtp:
-            full_text = self._normalize_mtp_interrupted_text(full_text, last_open)
-            logger.info(
-                f"流式 MTP 中断检测: ⟪ 位于 offset={last_open}, "
-                f"prefix_len={last_open}, fragment_len={len(full_text) - last_open}"
+            result = GenerationResult(
+                text=full_text,
+                finish_reason=finish_reason,
+                was_mtp_interrupted=was_mtp,
+                prefix_text=full_text[:last_open] if was_mtp else full_text,
+                mtp_fragment=full_text[last_open:] if was_mtp else "",
+                model_used=runtime_params["model"],
             )
-
-        result = GenerationResult(
-            text=full_text,
-            finish_reason=finish_reason,
-            was_mtp_interrupted=was_mtp,
-            prefix_text=full_text[:last_open] if was_mtp else full_text,
-            mtp_fragment=full_text[last_open:] if was_mtp else "",
-            model_used=runtime_params["model"],
-        )
-
-        yield StreamChunk(
-            delta="",
-            full_text=full_text,
-            is_final=True,
-            result=result,
-            mtp_detected=mtp_detected,
-        )
+            yield StreamChunk(
+                delta="",
+                full_text=full_text,
+                is_final=True,
+                result=result,
+                mtp_detected=mtp_detected,
+            )
+        finally:
+            close = getattr(response, "aclose", None)
+            if callable(close):
+                close_result = close()
+                if inspect.isawaitable(close_result):
+                    await close_result
 
 
 __all__ = [

--- a/src/hivememory/agent_runtime/execution/worker.py
+++ b/src/hivememory/agent_runtime/execution/worker.py
@@ -7,6 +7,7 @@ asyncio task 直接传播，不在本层维护额外的控制信号。
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 from collections.abc import AsyncGenerator
@@ -212,9 +213,14 @@ class WorkerAgentService:
         finally:
             close = getattr(response, "aclose", None)
             if callable(close):
-                close_result = close()
-                if inspect.isawaitable(close_result):
-                    await close_result
+                try:
+                    close_result = close()
+                    if inspect.isawaitable(close_result):
+                        await close_result
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.warning("关闭 LLM 流式响应失败", exc_info=True)
 
 
 __all__ = [

--- a/src/hivememory/agent_runtime/mtp/executor.py
+++ b/src/hivememory/agent_runtime/mtp/executor.py
@@ -20,8 +20,6 @@ class MTPExecutor(ABC):
         self,
         assistant_text: str,
         context: MTPExecutionContext,
-        *,
-        cancel_event=None,
     ) -> MTPExecutionResult | None:
         pass
 
@@ -36,13 +34,10 @@ class KoakumaMTPExecutor(MTPExecutor):
         self,
         assistant_text: str,
         context: MTPExecutionContext,
-        *,
-        cancel_event=None,
     ) -> MTPExecutionResult | None:
         return await self._koakuma.intercept_and_execute(
             assistant_text,
             context=context,
-            cancel_event=cancel_event,
         )
 
 

--- a/src/hivememory/agent_runtime/mtp/runtime.py
+++ b/src/hivememory/agent_runtime/mtp/runtime.py
@@ -26,7 +26,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
 from typing import TYPE_CHECKING, Any
@@ -223,8 +222,6 @@ class KoakumaRuntime:
         self,
         text: str,
         context: MTPExecutionContext | None = None,
-        *,
-        cancel_event: asyncio.Event | None = None,
     ) -> MTPExecutionResult:
         """
         执行 MTP 指令 (主入口)
@@ -252,7 +249,6 @@ class KoakumaRuntime:
             response = await self._route_and_execute(
                 command,
                 context or MTPExecutionContext(),
-                cancel_event=cancel_event,
             )
             response.execution_time_ms = (time.time() - start_time) * 1000
 
@@ -294,8 +290,6 @@ class KoakumaRuntime:
         self,
         assistant_text: str,
         context: MTPExecutionContext | None = None,
-        *,
-        cancel_event: asyncio.Event | None = None,
     ) -> MTPExecutionResult | None:
         """
         拦截检测 + 执行 (Section 3.1.2 Stop Sequence 场景)
@@ -318,23 +312,12 @@ class KoakumaRuntime:
         if last_open == -1:
             return None
 
-        if cancel_event is not None and cancel_event.is_set():
-            return MTPExecutionResult(
-                command=None,
-                response_status=MTPResponseStatus.CANCELLED.value,
-                response_content="",
-                formatted_response="",
-                success=False,
-                execution_time_ms=0.0,
-            )
-
         # 提取从 ⟪ 开始的文本片段
         mtp_fragment = assistant_text[last_open:]
 
         return await self.execute_mtp(
             mtp_fragment,
             context=context,
-            cancel_event=cancel_event,
         )
 
     # ========== 别名管理 ==========
@@ -355,8 +338,6 @@ class KoakumaRuntime:
         self,
         command: MTPCommand,
         context: MTPExecutionContext,
-        *,
-        cancel_event: asyncio.Event | None = None,
     ) -> MTPResponse:
         """
         路由并执行 MTP 指令 (Section 3)
@@ -387,8 +368,6 @@ class KoakumaRuntime:
             )
 
         try:
-            if cancel_event is not None and cancel_event.is_set():
-                return MTPResponse(status=MTPResponseStatus.CANCELLED, content="")
             # 权限沙箱：校验 MTP 动词权限 (Phase 1 多智能体)
             self._check_verb_permission(command.verb.value, context=context)
             return await handler(command, context)

--- a/src/hivememory/agent_runtime/runtime.py
+++ b/src/hivememory/agent_runtime/runtime.py
@@ -71,7 +71,6 @@ class AgentRuntime:
         *,
         generation_options: dict[str, Any] | None = None,
         output_sink: FrameOutputSink,
-        cancel_event=None,
     ) -> FrameExecutionResult:
         """跑一个 frame 到自然收敛或命中 CALL（非流式）。"""
         try:
@@ -88,7 +87,6 @@ class AgentRuntime:
             max_iterations=max_iterations,
             generation_options=generation_options,
             output_sink=output_sink,
-            cancel_event=cancel_event,
         )
 
     def apply_call_response(

--- a/src/hivememory/alice/application/agent_run_service.py
+++ b/src/hivememory/alice/application/agent_run_service.py
@@ -8,6 +8,7 @@ stream sequence 与 RuntimeEvent envelope 实现均不放在 application 层。
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from collections.abc import AsyncGenerator
@@ -199,7 +200,12 @@ class AgentRunService:
                     close_reason="stream_closed",
                 )
             if executor_stream is not None:
-                await executor_stream.aclose()
+                try:
+                    await executor_stream.aclose()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.warning("关闭 Agent executor stream 失败", exc_info=True)
 
     def _register_preretrieval_aliases(self, memories: list[MemoryAtom]) -> None:
         self._atom_cache.ingest_atoms(memories)

--- a/src/hivememory/alice/application/agent_run_service.py
+++ b/src/hivememory/alice/application/agent_run_service.py
@@ -8,7 +8,6 @@ stream sequence 与 RuntimeEvent envelope 实现均不放在 application 层。
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import uuid
 from collections.abc import AsyncGenerator
@@ -77,12 +76,10 @@ class AgentRunService:
         self,
         agent_run_context: AgentRunContext,
         generation_options: dict[str, Any] | None = None,
-        cancel_event: asyncio.Event | None = None,
         generation_id: str | None = None,
     ) -> AgentRunResult:
         session = self._create_run_session(
             generation_id=generation_id,
-            cancel_event=cancel_event,
         )
 
         run_events = self._events_for_run(session, agent_run_context)
@@ -124,12 +121,10 @@ class AgentRunService:
         self,
         agent_run_context: AgentRunContext,
         generation_options: dict[str, Any] | None = None,
-        cancel_event: asyncio.Event | None = None,
         generation_id: str | None = None,
     ) -> AsyncGenerator[dict[str, Any], None]:
         session = self._create_run_session(
             generation_id=generation_id,
-            cancel_event=cancel_event,
         )
 
         run_events = self._events_for_run(session, agent_run_context)
@@ -199,7 +194,6 @@ class AgentRunService:
             raise
         finally:
             if exit_reason == StreamExitReason.RUNNING:
-                session.cancel_event.set()
                 run_events.cancelled(
                     message="Agent stream closed before terminal event.",
                     close_reason="stream_closed",
@@ -280,12 +274,10 @@ class AgentRunService:
     def _create_run_session(
         *,
         generation_id: str | None,
-        cancel_event: asyncio.Event | None,
     ) -> RunSession:
         return RunSession(
             agent_run_id=f"agent_run_{uuid.uuid4().hex}",
             generation_id=generation_id,
-            cancel_event=cancel_event if cancel_event is not None else asyncio.Event(),
         )
 
     @staticmethod

--- a/src/hivememory/alice/orchestration/__init__.py
+++ b/src/hivememory/alice/orchestration/__init__.py
@@ -7,13 +7,11 @@ from hivememory.alice.orchestration.sub_agent import (
     CallContext,
     CallContextProvider,
     CallCoordinator,
-    CancelRun,
     DispatchCallee,
     ResumeCaller,
 )
 
 __all__ = [
-    "CancelRun",
     "CallContext",
     "CallContextProvider",
     "CallCoordinator",

--- a/src/hivememory/alice/orchestration/run_executor.py
+++ b/src/hivememory/alice/orchestration/run_executor.py
@@ -13,7 +13,6 @@ from hivememory.agent_runtime.products import RuntimeProducts
 from hivememory.alice.orchestration.run_output import AgentRunOutput, NullAgentRunOutput
 from hivememory.alice.orchestration.run_session import RunSession
 from hivememory.alice.orchestration.sub_agent.call_coordinator import (
-    CancelRun,
     DispatchCallee,
     ResumeCaller,
 )
@@ -83,7 +82,7 @@ class RunExecutor:
             self._abort_cancelled_run()
             raise
 
-        return self._finish(self._normalize_terminal_result(result, self._session.cancel_event))
+        return self._finish(result)
 
     async def _execute_frame(
         self,
@@ -107,7 +106,6 @@ class RunExecutor:
                 frame,
                 generation_options=generation_options,
                 output_sink=frame_output,
-                cancel_event=self._session.cancel_event,
             )
 
             match result.status:
@@ -131,8 +129,6 @@ class RunExecutor:
                     match outcome:
                         case ResumeCaller():
                             continue
-                        case CancelRun():
-                            return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
                         case _:
                             raise RuntimeError(
                                 f"CALL execution returned an unsupported outcome: {outcome!r}"
@@ -160,7 +156,7 @@ class RunExecutor:
         generation_options: dict[str, Any] | None,
         run_output: AgentRunOutput,
         output_context: _FrameOutputContext,
-    ) -> ResumeCaller | CancelRun:
+    ) -> ResumeCaller:
         coordinator = self._require_call_coordinator()
         try:
             outcome = await coordinator.begin_call(
@@ -190,13 +186,13 @@ class RunExecutor:
                         run_output=run_output,
                     )
                     match completion:
-                        case ResumeCaller() | CancelRun():
+                        case ResumeCaller():
                             return completion
                         case _:
                             raise RuntimeError(
                                 f"CALL completion returned an unsupported outcome: {completion!r}"
                             )
-                case ResumeCaller() | CancelRun():
+                case ResumeCaller():
                     return outcome
                 case _:
                     raise RuntimeError(
@@ -223,7 +219,6 @@ class RunExecutor:
 
     def _abort_cancelled_run(self) -> None:
         """协程取消沿递归栈清理 CALL 后，在最外层收尾整个 run。"""
-        self._session.cancel_event.set()
         self._session.cancel_unapplied_calls()
         if self.terminal_result is None:
             self._finish(FrameExecutionResult(status=FrameExecutionStatus.CANCELLED))
@@ -262,15 +257,5 @@ class RunExecutor:
         action_id = suspension.suspend_action_id
         if not action_id:
             raise RuntimeError("CALL suspension is missing its action id.")
-
-    @staticmethod
-    def _normalize_terminal_result(
-        result: FrameExecutionResult,
-        cancel_event: asyncio.Event,
-    ) -> FrameExecutionResult:
-        if cancel_event.is_set() and result.status != FrameExecutionStatus.CANCELLED:
-            return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
-        return result
-
 
 __all__ = ["RunExecutor"]

--- a/src/hivememory/alice/orchestration/run_executor.py
+++ b/src/hivememory/alice/orchestration/run_executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -21,6 +22,8 @@ from hivememory.alice.orchestration.sub_agent.call_record import CallRecord
 if TYPE_CHECKING:
     from hivememory.agent_runtime.runtime import AgentRuntime
     from hivememory.alice.orchestration.sub_agent.call_coordinator import CallCoordinator
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,7 +82,10 @@ class RunExecutor:
                 output_context=_FrameOutputContext(),
             )
         except asyncio.CancelledError:
-            self._abort_cancelled_run()
+            try:
+                self._abort_cancelled_run()
+            except Exception:
+                logger.warning("取消 Agent run 收尾失败", exc_info=True)
             raise
 
         return self._finish(result)
@@ -199,7 +205,10 @@ class RunExecutor:
                         f"CALL preparation returned an unsupported outcome: {outcome!r}"
                     )
         except asyncio.CancelledError:
-            self._cancel_call_if_registered(caller_frame, suspension)
+            try:
+                self._cancel_call_if_registered(caller_frame, suspension)
+            except Exception:
+                logger.warning("取消 CALL 收尾失败", exc_info=True)
             raise
 
     def _cancel_call_if_registered(
@@ -219,9 +228,15 @@ class RunExecutor:
 
     def _abort_cancelled_run(self) -> None:
         """协程取消沿递归栈清理 CALL 后，在最外层收尾整个 run。"""
-        self._session.cancel_unapplied_calls()
+        try:
+            self._session.cancel_unapplied_calls()
+        except Exception:
+            logger.warning("取消未回填 CALL 失败", exc_info=True)
         if self.terminal_result is None:
-            self._finish(FrameExecutionResult(status=FrameExecutionStatus.CANCELLED))
+            try:
+                self._finish(FrameExecutionResult(status=FrameExecutionStatus.CANCELLED))
+            except Exception:
+                logger.warning("收尾已取消 Agent run 失败", exc_info=True)
 
     def _finish(self, result: FrameExecutionResult) -> FrameExecutionResult:
         if self.terminal_result is not None:

--- a/src/hivememory/alice/orchestration/run_session.py
+++ b/src/hivememory/alice/orchestration/run_session.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 
 from hivememory.agent_runtime.models import ExecutionFrame
@@ -11,13 +10,12 @@ from hivememory.alice.orchestration.sub_agent.call_record import CallRecord, Cal
 class RunSession:
     """一次 Alice run 独占的可变状态（run-local 控制面）。
 
-    保存帧注册表、CALL 记账与取消信号。frame 的挂起与恢复由 run-local
+    保存帧注册表与 CALL 记账。frame 的挂起与恢复由 run-local
     递归执行器的协程栈表达，Session 不充当调度程序计数器。
     """
 
     agent_run_id: str
     generation_id: str | None = None
-    cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
     frames: dict[str, ExecutionFrame] = field(default_factory=dict)
     root_frame_id: str | None = None
     call_records: dict[tuple[str, str], CallRecord] = field(default_factory=dict)

--- a/src/hivememory/alice/orchestration/sub_agent/__init__.py
+++ b/src/hivememory/alice/orchestration/sub_agent/__init__.py
@@ -8,7 +8,6 @@ from hivememory.alice.orchestration.sub_agent.call_coordinator import (
     CallCompletionResult,
     CallCoordinator,
     CallStartResult,
-    CancelRun,
     DispatchCallee,
     ResumeCaller,
 )
@@ -22,7 +21,6 @@ __all__ = [
     "CallRecord",
     "CallRecordStatus",
     "CallStartResult",
-    "CancelRun",
     "DispatchCallee",
     "ResumeCaller",
 ]

--- a/src/hivememory/alice/orchestration/sub_agent/call_coordinator.py
+++ b/src/hivememory/alice/orchestration/sub_agent/call_coordinator.py
@@ -21,7 +21,6 @@ from hivememory.alice.orchestration.run_output import (
 from hivememory.alice.orchestration.sub_agent.call_context_provider import CallContextProvider
 from hivememory.alice.orchestration.sub_agent.call_record import CallRecord, CallRecordStatus
 from hivememory.alice.orchestration.sub_agent.call_response import (
-    cancelled_response,
     preparation_error_response,
     response_for_frame_result,
 )
@@ -49,13 +48,8 @@ class ResumeCaller:
     """CALL 已完成回填，执行器可以重入原 caller。"""
 
 
-@dataclass(frozen=True)
-class CancelRun:
-    """全局取消在 CALL 提交前胜出，终止当前 run。"""
-
-
-type CallStartResult = DispatchCallee | ResumeCaller | CancelRun
-type CallCompletionResult = ResumeCaller | CancelRun
+type CallStartResult = DispatchCallee | ResumeCaller
+type CallCompletionResult = ResumeCaller
 type _PreparationResult = ExecutionFrame | MTPCallResponse
 
 
@@ -87,8 +81,8 @@ class CallCoordinator:
 
         output = run_output or NullAgentRunOutput()
 
-        call_request = suspension.call_request
         action_id = suspension.suspend_action_id
+        call_request = suspension.call_request
 
         session.require_frame(caller_frame)
 
@@ -101,13 +95,7 @@ class CallCoordinator:
             call_request.task[:80],
         )
 
-        prepared = (
-            cancelled_response(call_request.target_alias)
-            if session.cancel_event.is_set()
-            else await self._prepare_callee(caller_frame, call_request)
-        )
-        if session.cancel_event.is_set():
-            prepared = cancelled_response(call_request.target_alias)
+        prepared = await self._prepare_callee(caller_frame, call_request)
 
         match prepared:
             case ExecutionFrame() as callee_frame:
@@ -129,7 +117,6 @@ class CallCoordinator:
                     suspension,
                     response,
                     record=record,
-                    cancel_run=session.cancel_event.is_set(),
                     callee_frame=None,
                     callee_result=None,
                     run_output=output,
@@ -231,27 +218,17 @@ class CallCoordinator:
         if callee_result.status == FrameExecutionStatus.SUSPENDED:
             raise ValueError("CallCoordinator.complete_call requires a terminal callee result.")
 
-        cancel_run = session.cancel_event.is_set()
-        result_for_finalization = (
-            FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
-            if cancel_run
-            else callee_result
-        )
         effective_result, frame_products = self._finalize_callee(
             callee_frame,
-            result_for_finalization,
+            callee_result,
         )
-        response = (
-            cancelled_response(call_request.target_alias)
-            if cancel_run
-            else response_for_frame_result(
-                call_request.target_alias,
-                effective_result,
-                reply="".join(callee_frame.progress.text_segments),
-                artifact_aliases=frame_products.artifact_aliases,
-                profile=callee_frame.agent_profile,
-                generation_options=generation_options,
-            )
+        response = response_for_frame_result(
+            call_request.target_alias,
+            effective_result,
+            reply="".join(callee_frame.progress.text_segments),
+            artifact_aliases=frame_products.artifact_aliases,
+            profile=callee_frame.agent_profile,
+            generation_options=generation_options,
         )
 
         return await self._commit_response(
@@ -259,7 +236,6 @@ class CallCoordinator:
             suspension,
             response,
             record=record,
-            cancel_run=cancel_run,
             callee_frame=callee_frame,
             callee_result=effective_result,
             run_output=output,
@@ -273,7 +249,6 @@ class CallCoordinator:
         session: RunSession,
     ) -> None:
         """协程取消时收尾未 apply 的 CALL，并回填 cancelled response。"""
-        call_request = suspension.call_request
         action_id = suspension.suspend_action_id
         record = session.require_call(caller_frame, action_id)
         if record.status in {CallRecordStatus.APPLIED, CallRecordStatus.CANCELLED}:
@@ -294,12 +269,7 @@ class CallCoordinator:
                 logger.exception("Failed to finalize cancelled sub-agent frame")
         if record.status == CallRecordStatus.RESOLVING:
             record.mark_resolved()
-        self._agent_runtime.apply_call_response(
-            caller_frame,
-            suspension,
-            cancelled_response(call_request.target_alias),
-        )
-        record.mark_applied()
+        record.cancel()
 
     async def _commit_response(
         self,
@@ -308,7 +278,6 @@ class CallCoordinator:
         response: MTPCallResponse,
         *,
         record: CallRecord,
-        cancel_run: bool,
         callee_frame: ExecutionFrame | None,
         callee_result: FrameExecutionResult | None,
         run_output: AgentRunOutput,
@@ -318,7 +287,7 @@ class CallCoordinator:
         action_id = suspension.suspend_action_id
 
         record.mark_resolved()
-        
+
         self._agent_runtime.apply_call_response(caller_frame, suspension, response)
         record.mark_applied()
 
@@ -331,7 +300,7 @@ class CallCoordinator:
             callee_result=callee_result,
             run_output=run_output,
         )
-        return CancelRun() if cancel_run else ResumeCaller()
+        return ResumeCaller()
 
     def _finalize_callee(
         self,
@@ -391,7 +360,6 @@ __all__ = [
     "CallCompletionResult",
     "CallCoordinator",
     "CallStartResult",
-    "CancelRun",
     "DispatchCallee",
     "ResumeCaller",
 ]

--- a/src/hivememory/alice/runtime/streaming.py
+++ b/src/hivememory/alice/runtime/streaming.py
@@ -155,7 +155,6 @@ class AgentRunStream:
                 try:
                     return await runner
                 except asyncio.CancelledError:
-                    self._session.cancel_event.set()
                     raise
                 finally:
                     # runner 自身被取消时，仍要唤醒正在消费的客户端；只有消费端已经
@@ -174,7 +173,6 @@ class AgentRunStream:
             finally:
                 consumer_closed.set()
                 if not task.done():
-                    self._session.cancel_event.set()
                     task.cancel()
                     with suppress(asyncio.CancelledError):
                         await task

--- a/src/hivememory/alice/runtime/streaming.py
+++ b/src/hivememory/alice/runtime/streaming.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncGenerator, Awaitable, Mapping
-from contextlib import suppress
 from typing import Any, Literal
 
 from hivememory.agent_runtime.models import ExecutionFrame, FrameExecutionResult
@@ -21,6 +21,24 @@ from hivememory.alice.orchestration.run_output import (
     CallOutputStarted,
 )
 from hivememory.alice.orchestration.run_session import RunSession
+
+logger = logging.getLogger(__name__)
+
+
+async def _cancel_and_join(task: asyncio.Task[Any]) -> None:
+    """取消并等待 runner，同时保留当前消费 task 自己收到的取消。"""
+    owner = asyncio.current_task()
+    entry_cancelling = owner.cancelling() if owner is not None else 0
+
+    if not task.done():
+        task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        if owner is not None and owner.cancelling() > entry_cancelling:
+            raise
+    except Exception:
+        logger.warning("取消 Agent runner 收尾失败", exc_info=True)
 
 
 class _BoundFrameOutputSink:
@@ -173,9 +191,7 @@ class AgentRunStream:
             finally:
                 consumer_closed.set()
                 if not task.done():
-                    task.cancel()
-                    with suppress(asyncio.CancelledError):
-                        await task
+                    await _cancel_and_join(task)
                 elif not task.cancelled():
                     # 若消费端在 runner 异常后、读取 sentinel 前关闭，主动取出异常，
                     # 避免产生 "Task exception was never retrieved"；正常消费路径仍会

--- a/src/hivememory/core/protocol/__init__.py
+++ b/src/hivememory/core/protocol/__init__.py
@@ -3,7 +3,6 @@
 from hivememory.core.protocol.gateway import (
     CommandExecutionResult,
     CommandExecutionStatus,
-    GatewayCancelledError,
     GatewayCommandOutcome,
     GatewayDecision,
     GatewayDecisionOutcome,
@@ -15,7 +14,6 @@ from hivememory.core.protocol.gateway import (
     RetrievalMode,
     RetrievalPlan,
 )
-
 from hivememory.core.protocol.models import (
     InteractionPayload,
     MessageType,
@@ -30,7 +28,6 @@ __all__ = [
     "RetrievalRequest",
     "CommandExecutionResult",
     "CommandExecutionStatus",
-    "GatewayCancelledError",
     "GatewayCommandOutcome",
     "GatewayDecision",
     "GatewayDecisionOutcome",

--- a/src/hivememory/core/protocol/gateway.py
+++ b/src/hivememory/core/protocol/gateway.py
@@ -135,10 +135,6 @@ class GatewayControlError(RuntimeError):
     """Gateway 请求控制异常基类。"""
 
 
-class GatewayCancelledError(GatewayControlError):
-    """Gateway 请求被调用方取消。"""
-
-
 class GatewayTimeoutError(GatewayControlError):
     """Gateway 无法在 deadline 内形成完整终态。"""
 
@@ -146,7 +142,6 @@ class GatewayTimeoutError(GatewayControlError):
 __all__ = [
     "CommandExecutionResult",
     "CommandExecutionStatus",
-    "GatewayCancelledError",
     "GatewayCommandOutcome",
     "GatewayControlError",
     "GatewayDecision",

--- a/src/hivememory/gateway/service.py
+++ b/src/hivememory/gateway/service.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-
 from hivememory.core.models import Identity
 from hivememory.core.protocol.gateway import (
     GatewayIngressMode,
@@ -28,7 +26,6 @@ class GatewayService:
         *,
         identity: Identity,
         ingress_mode: GatewayIngressMode,
-        cancel_event: asyncio.Event | None = None,
         request_timeout_ms: int | None = None,
     ) -> GatewayProcessResult:
         """把一次 Gateway 请求完整委托给 Runtime 持有的 workflow。"""
@@ -44,7 +41,6 @@ class GatewayService:
             message,
             identity=identity,
             ingress_mode=ingress_mode,
-            cancel_event=cancel_event,
             request_timeout_ms=effective_timeout_ms,
         )
 

--- a/src/hivememory/gateway/workflow/workflow.py
+++ b/src/hivememory/gateway/workflow/workflow.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import suppress
 from time import perf_counter
 from typing import Any
 
 from hivememory.core.models import Identity
 from hivememory.core.protocol.gateway import (
-    GatewayCancelledError,
     GatewayIngressMode,
     GatewayProcessResult,
     GatewayTimeoutError,
@@ -51,7 +49,6 @@ class GatewayWorkflow:
         *,
         identity: Identity,
         ingress_mode: GatewayIngressMode,
-        cancel_event: asyncio.Event | None = None,
         request_timeout_ms: int | None = None,
     ) -> GatewayProcessResult:
         """执行 Entry、固定 topic 前缀和唯一 analysis 分支。"""
@@ -81,7 +78,6 @@ class GatewayWorkflow:
                 state,
                 self._entry_step,
                 completed_steps,
-                cancel_event=cancel_event,
                 deadline=deadline,
             )
             if deadline_reached:
@@ -98,7 +94,6 @@ class GatewayWorkflow:
                     state,
                     self._command_dispatch_step,
                     completed_steps,
-                    cancel_event=cancel_event,
                     deadline=deadline,
                 )
                 if deadline_reached:
@@ -114,7 +109,6 @@ class GatewayWorkflow:
                     state,
                     step,
                     completed_steps,
-                    cancel_event=cancel_event,
                     deadline=deadline,
                 )
                 if deadline_reached:
@@ -132,7 +126,6 @@ class GatewayWorkflow:
                 state,
                 analysis_step,
                 completed_steps,
-                cancel_event=cancel_event,
                 deadline=deadline,
             )
             if deadline_reached:
@@ -142,18 +135,6 @@ class GatewayWorkflow:
             outcome = state.finalize()
             self._emit_completed(outcome, completed_steps, started_at)
             return outcome
-        except GatewayCancelledError:
-            self._emit(
-                RuntimeEventType.GATEWAY_WORKFLOW_CANCELLED,
-                reason="cancelled",
-                data={
-                    "step_id": current_step_id,
-                    "ingress_mode": ingress_mode.value,
-                    "completed_steps": completed_steps,
-                    "duration_ms": _elapsed_ms(started_at),
-                },
-            )
-            raise
         except Exception as exc:
             self._emit(
                 RuntimeEventType.GATEWAY_WORKFLOW_FAILED,
@@ -174,13 +155,11 @@ class GatewayWorkflow:
         step: GatewayWorkflowStep[Any, Any],
         step_index: int,
         *,
-        cancel_event: asyncio.Event | None = None,
         deadline: float | None = None,
     ) -> bool:
         """统一执行一次 Step，并保证只有一次 state apply。"""
 
         step_started_at = perf_counter()
-        self._raise_if_cancelled(cancel_event)
         selected_input = step.select_input(state.snapshot())
         is_fallback = False
         fallback_reason: str | None = None
@@ -230,10 +209,11 @@ class GatewayWorkflow:
         )
 
         try:
-            output = await self._invoke_with_control(
-                step.invoke(selected_input),
-                timeout=effective_timeout,
-                cancel_event=cancel_event,
+            invocation = step.invoke(selected_input)
+            output = (
+                await asyncio.wait_for(invocation, timeout=effective_timeout)
+                if effective_timeout is not None
+                else await invocation
             )
         except (TimeoutError, RecoverableGatewayError) as exc:
             if step.fallback is None:
@@ -275,55 +255,6 @@ class GatewayWorkflow:
             flow_end_reason=flow_end_reason,
         )
         return is_fallback and fallback_reason == "GatewayTimeoutError"
-
-    async def _invoke_with_control(
-        self,
-        invocation,
-        *,
-        timeout: float | None,
-        cancel_event: asyncio.Event | None,
-    ):
-        """等待一次能力调用，并在取消或超时时终止其任务。"""
-
-        self._raise_if_cancelled(cancel_event)
-        invoke_task = asyncio.create_task(invocation)
-        cancel_task = (
-            asyncio.create_task(cancel_event.wait())
-            if cancel_event is not None
-            else None
-        )
-        wait_set = {invoke_task}
-        if cancel_task is not None:
-            wait_set.add(cancel_task)
-
-        try:
-            done, _pending = await asyncio.wait(
-                wait_set,
-                timeout=timeout,
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            if cancel_task is not None and cancel_task in done:
-                invoke_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await invoke_task
-                raise GatewayCancelledError("Gateway 请求已取消")
-            if invoke_task in done:
-                return await invoke_task
-
-            invoke_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await invoke_task
-            raise TimeoutError("Gateway Step timeout")
-        finally:
-            if cancel_task is not None:
-                cancel_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await cancel_task
-
-    @staticmethod
-    def _raise_if_cancelled(cancel_event: asyncio.Event | None) -> None:
-        if cancel_event is not None and cancel_event.is_set():
-            raise GatewayCancelledError("Gateway 请求已取消")
 
     @staticmethod
     def _remaining_seconds(deadline: float | None) -> float | None:

--- a/src/hivememory/server/routers/chat.py
+++ b/src/hivememory/server/routers/chat.py
@@ -18,11 +18,17 @@ logger = logging.getLogger(__name__)
 
 async def _cancel_and_join(task: asyncio.Task) -> None:
     """Cancel and settle one in-flight Chat stream pull."""
+    owner = asyncio.current_task()
+    entry_cancelling = owner.cancelling() if owner is not None else 0
+
     if not task.done():
         task.cancel()
     try:
         await task
-    except (asyncio.CancelledError, StopAsyncIteration):
+    except asyncio.CancelledError:
+        if owner is not None and owner.cancelling() > entry_cancelling:
+            raise
+    except StopAsyncIteration:
         pass
     except Exception:
         logger.debug("SSE pull task cleanup failed", exc_info=True)

--- a/src/hivememory/server/routers/chat.py
+++ b/src/hivememory/server/routers/chat.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import logging
 import uuid
-from contextlib import suppress
 
 from fastapi import APIRouter, Depends, Request
 from sse_starlette.sse import EventSourceResponse
@@ -15,6 +14,18 @@ from hivememory.system.application.chat_service import ChatApplicationService
 
 router = APIRouter(tags=["chat"])
 logger = logging.getLogger(__name__)
+
+
+async def _cancel_and_join(task: asyncio.Task) -> None:
+    """Cancel and settle one in-flight Chat stream pull."""
+    if not task.done():
+        task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, StopAsyncIteration):
+        pass
+    except Exception:
+        logger.debug("SSE pull task cleanup failed", exc_info=True)
 
 
 @router.post("/chat")
@@ -28,6 +39,7 @@ async def chat(
 
     async def event_generator():
         stream = None
+
         try:
             stream = service.chat_stream(
                 user_message=body.message,
@@ -44,38 +56,34 @@ async def chat(
             )
 
             while True:
-                next_event_task = asyncio.create_task(stream.__anext__())
-                while not next_event_task.done():
-                    if await request.is_disconnected():
-                        if generation_id:
-                            service.cancel_generation(generation_id, reason="client_disconnected")
-                        next_event_task.cancel()
-                        with suppress(asyncio.CancelledError):
-                            await next_event_task
-                        return
-                    await asyncio.sleep(0.1)
-
+                pull_task = asyncio.create_task(stream.__anext__())
                 try:
-                    event = next_event_task.result()
+                    while not pull_task.done():
+                        if await request.is_disconnected():
+                            service.cancel_generation(generation_id, reason="client_disconnected")
+                            return
+                        await asyncio.sleep(0.1)
+
+                    event = await pull_task
+
+                    yield {
+                        "event": event["event"],
+                        "data": json.dumps(event["data"], ensure_ascii=False, default=str),
+                    }
+
+                    if await request.is_disconnected():
+                        service.cancel_generation(generation_id, reason="client_disconnected")
+                        break
                 except StopAsyncIteration:
                     break
+                except asyncio.CancelledError:
+                    service.cancel_generation(generation_id, reason="client_disconnected")
+                    raise
+                finally:
+                    await _cancel_and_join(pull_task)
 
-                yield {
-                    "event": event["event"],
-                    "data": json.dumps(event["data"], ensure_ascii=False, default=str),
-                }
-
-                if await request.is_disconnected():
-                    if generation_id:
-                        service.cancel_generation(generation_id, reason="client_disconnected")
-                    break
-
-        except asyncio.CancelledError:
-            if generation_id:
-                service.cancel_generation(generation_id, reason="client_disconnected")
-            raise
-        except Exception as e:
-            logger.error(f"chat route stream error: {e}", exc_info=True)
+        except Exception:
+            logger.exception("chat route stream error")
             yield {
                 "event": "error",
                 "data": json.dumps(
@@ -85,7 +93,10 @@ async def chat(
             }
         finally:
             if stream is not None:
-                await stream.aclose()
+                try:
+                    await stream.aclose()
+                except Exception:
+                    logger.warning("关闭 Chat stream 失败", exc_info=True)
 
     return EventSourceResponse(event_generator())
 

--- a/src/hivememory/system/application/chat_service.py
+++ b/src/hivememory/system/application/chat_service.py
@@ -10,16 +10,16 @@ v0.4.0 Phase 1 变更：
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
 from hivememory.core.models import Identity
 from hivememory.core.protocol.gateway import (
     CommandExecutionResult,
-    GatewayCancelledError,
     GatewayIngressMode,
 )
 from hivememory.core.protocol.models import AgentRunResult, AgentRunStatus
@@ -35,11 +35,64 @@ from hivememory.system.runtime.control import (
     CancelResult,
     ChatGenerationRun,
     ChatGenerationRunRegistry,
-    ChatGenerationRunStatus,
+    ChatRunOutcome,
+    ChatRunPhase,
 )
 from hivememory.system.runtime.events import NullRuntimeEventSink, RuntimeEventSink
 
 logger = logging.getLogger(__name__)
+
+
+class _ChatRunCancelled(Exception):  # noqa: N818 - 设计要求使用私有领域分支名
+    """Chat application 内部的用户 stop 分支。"""
+
+    def __init__(self, phase: ChatRunPhase, reason: str) -> None:
+        super().__init__(f"{phase.value} cancelled: {reason}")
+        self.phase = phase
+        self.reason = reason
+
+
+async def _run_interruptible(
+    control: ChatGenerationRun,
+    phase: ChatRunPhase,
+    operation_factory: Callable[[], Awaitable[Any]],
+) -> Any:
+    """用 Chat application 自有 child task 包装一个可中断阶段。"""
+    owner_task = asyncio.current_task()
+    if owner_task is None:
+        raise RuntimeError("_run_interruptible 必须运行在 asyncio task 中")
+    entry_cancelling = owner_task.cancelling()
+
+    if control.outcome is ChatRunOutcome.STOP_REQUESTED:
+        raise _ChatRunCancelled(phase, control.stop_reason or "user_requested")
+
+    async def invoke() -> Any:
+        return await operation_factory()
+
+    task = asyncio.create_task(invoke())
+    control.bind_phase(phase, task)
+    try:
+        result = await task
+        if control.outcome is ChatRunOutcome.STOP_REQUESTED:
+            raise _ChatRunCancelled(
+                phase,
+                control.stop_reason or "user_requested",
+            )
+        return result
+    except asyncio.CancelledError:
+        if owner_task.cancelling() > entry_cancelling:
+            raise
+        if (
+            control.outcome is ChatRunOutcome.STOP_REQUESTED
+            and control.active_task is task
+        ):
+            raise _ChatRunCancelled(
+                phase,
+                control.stop_reason or "user_requested",
+            ) from None
+        raise
+    finally:
+        control.unbind_phase(task)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -107,19 +160,22 @@ class ChatApplicationService:
         )
 
         try:
-            run.status = ChatGenerationRunStatus.PREPARING
+            run.enter_phase(ChatRunPhase.GATEWAY)
             self._emit_chat_status(run, trace_id=trace_id, agent_id=agent_id)
-            gateway_result = await self._bus.request(
-                GlobalRoutes.GATEWAY_PROCESS,
-                message=user_message,
-                identity=identity,
-                ingress_mode=GatewayIngressMode.ACTIVE_CHAT,
-                cancel_event=run.cancel_event,
-                request_timeout_ms=self._gateway_request_timeout_ms,
+            gateway_result = await _run_interruptible(
+                run,
+                ChatRunPhase.GATEWAY,
+                lambda: self._bus.request(
+                    GlobalRoutes.GATEWAY_PROCESS,
+                    message=user_message,
+                    identity=identity,
+                    ingress_mode=GatewayIngressMode.ACTIVE_CHAT,
+                    request_timeout_ms=self._gateway_request_timeout_ms,
+                ),
             )
 
             if gateway_result.kind == "command":
-                run.status = ChatGenerationRunStatus.COMPLETED
+                run.mark_completed()
                 self._emit_chat_event(
                     RuntimeEventType.CHAT_RUN_COMPLETED,
                     run,
@@ -130,6 +186,12 @@ class ChatApplicationService:
                     command_execution_result=(gateway_result.command_execution_result)
                 )
 
+            if run.outcome is ChatRunOutcome.STOP_REQUESTED:
+                raise _ChatRunCancelled(
+                    ChatRunPhase.PREPARE,
+                    run.stop_reason or "user_requested",
+                )
+            run.enter_phase(ChatRunPhase.PREPARE)
             prepared = await self._bus.request(
                 GlobalRoutes.PATCHOULI_PREPARE_AGENT_RUN,
                 user_message=user_message,
@@ -141,28 +203,27 @@ class ChatApplicationService:
                 generation_options=generation_options,
             )
 
-            if run.cancelled:
-                run.status = ChatGenerationRunStatus.CANCELLED
-                self._emit_chat_event(
-                    RuntimeEventType.CHAT_RUN_CANCELLED,
-                    run,
-                    trace_id=trace_id,
-                    agent_id=agent_id,
+            if run.outcome is ChatRunOutcome.STOP_REQUESTED:
+                raise _ChatRunCancelled(
+                    ChatRunPhase.PREPARE,
+                    run.stop_reason or "user_requested",
                 )
-                return NonStreamingChatAgentOutcome(agent_run_result=self._cancelled_agent_result())
 
-            run.status = ChatGenerationRunStatus.STREAMING
+            run.enter_phase(ChatRunPhase.ALICE)
             self._emit_chat_status(run, trace_id=trace_id, agent_id=agent_id)
-            loop_result: AgentRunResult = await self._bus.request(
-                GlobalRoutes.ALICE_RUN_AGENT,
-                agent_run_context=prepared.agent_run_context,
-                generation_options=prepared.generation_options,
-                cancel_event=run.cancel_event,
-                generation_id=run.generation_id,
+            loop_result: AgentRunResult = await _run_interruptible(
+                run,
+                ChatRunPhase.ALICE,
+                lambda: self._bus.request(
+                    GlobalRoutes.ALICE_RUN_AGENT,
+                    agent_run_context=prepared.agent_run_context,
+                    generation_options=prepared.generation_options,
+                    generation_id=run.generation_id,
+                ),
             )
 
-            if run.cancelled or loop_result.status == AgentRunStatus.CANCELLED.value:
-                run.status = ChatGenerationRunStatus.CANCELLED
+            if loop_result.status == AgentRunStatus.CANCELLED.value:
+                run.mark_cancelled()
                 self._emit_chat_event(
                     RuntimeEventType.CHAT_RUN_CANCELLED,
                     run,
@@ -174,7 +235,7 @@ class ChatApplicationService:
                     agent_run_result=self._cancelled_agent_result(loop_result)
                 )
             if loop_result.status == AgentRunStatus.FAILED.value:
-                run.status = ChatGenerationRunStatus.FAILED
+                run.mark_failed()
                 self._emit_chat_event(
                     RuntimeEventType.CHAT_RUN_FAILED,
                     run,
@@ -185,7 +246,11 @@ class ChatApplicationService:
                 )
                 return NonStreamingChatAgentOutcome(agent_run_result=loop_result)
 
-            run.status = ChatGenerationRunStatus.FINALIZING
+            if not run.try_enter_finalizing():
+                raise _ChatRunCancelled(
+                    run.phase,
+                    run.stop_reason or "user_requested",
+                )
             self._emit_chat_status(
                 run,
                 trace_id=trace_id,
@@ -199,7 +264,7 @@ class ChatApplicationService:
             )
             prepared_finalized = True
 
-            run.status = ChatGenerationRunStatus.COMPLETED
+            run.mark_completed()
             self._emit_chat_event(
                 RuntimeEventType.CHAT_RUN_COMPLETED,
                 run,
@@ -208,17 +273,19 @@ class ChatApplicationService:
                 topic_id=prepared.topic_id,
             )
             return NonStreamingChatAgentOutcome(agent_run_result=loop_result)
-        except GatewayCancelledError:
-            run.status = ChatGenerationRunStatus.CANCELLED
+        except _ChatRunCancelled as cancelled:
+            run.mark_cancelled()
             self._emit_chat_event(
                 RuntimeEventType.CHAT_RUN_CANCELLED,
                 run,
                 trace_id=trace_id,
                 agent_id=agent_id,
+                topic_id=prepared.topic_id if prepared is not None else None,
+                data={"phase": cancelled.phase.value},
             )
             return NonStreamingChatAgentOutcome(agent_run_result=self._cancelled_agent_result())
         except Exception:
-            run.status = ChatGenerationRunStatus.FAILED
+            run.mark_failed()
             self._emit_chat_event(
                 RuntimeEventType.CHAT_RUN_FAILED,
                 run,
@@ -238,7 +305,7 @@ class ChatApplicationService:
                     )
                 except Exception:
                     logger.warning("清理 prepared run 失败", exc_info=True)
-            self._registry.close(run.generation_id, run.status)
+            self._registry.close(run.generation_id)
             reset_trace_context(tokens)
 
     # ========== 流式主链路 ==========
@@ -269,6 +336,7 @@ class ChatApplicationService:
         terminal_state: Literal["completed", "cancelled", "failed"] | None = None
         # finalize 成功后 Patchouli 已接管本轮交互，不再清理 prepared run。
         prepared_finalized = False
+        owner_task = asyncio.current_task()
         identity = Identity(
             user_id=user_id,
             agent_id=agent_id,
@@ -286,20 +354,23 @@ class ChatApplicationService:
             )
             yield {"event": "generation_id", "data": {"generation_id": run.generation_id}}
 
-            run.status = ChatGenerationRunStatus.PREPARING
+            run.enter_phase(ChatRunPhase.GATEWAY)
             self._emit_chat_status(run, trace_id=trace_id, agent_id=agent_id)
-            gateway_result = await self._bus.request(
-                GlobalRoutes.GATEWAY_PROCESS,
-                message=user_message,
-                identity=identity,
-                ingress_mode=GatewayIngressMode.ACTIVE_CHAT,
-                cancel_event=run.cancel_event,
-                request_timeout_ms=self._gateway_request_timeout_ms,
+            gateway_result = await _run_interruptible(
+                run,
+                ChatRunPhase.GATEWAY,
+                lambda: self._bus.request(
+                    GlobalRoutes.GATEWAY_PROCESS,
+                    message=user_message,
+                    identity=identity,
+                    ingress_mode=GatewayIngressMode.ACTIVE_CHAT,
+                    request_timeout_ms=self._gateway_request_timeout_ms,
+                ),
             )
 
             if gateway_result.kind == "command":
                 command_result = gateway_result.command_execution_result
-                run.status = ChatGenerationRunStatus.COMPLETED
+                run.mark_completed()
                 self._emit_chat_event(
                     RuntimeEventType.CHAT_RUN_COMPLETED,
                     run,
@@ -315,6 +386,12 @@ class ChatApplicationService:
                 yield self._command_done(run, command_result)
                 return
 
+            if run.outcome is ChatRunOutcome.STOP_REQUESTED:
+                raise _ChatRunCancelled(
+                    ChatRunPhase.PREPARE,
+                    run.stop_reason or "user_requested",
+                )
+            run.enter_phase(ChatRunPhase.PREPARE)
             prepared = await self._bus.request(
                 GlobalRoutes.PATCHOULI_PREPARE_AGENT_RUN,
                 user_message=user_message,
@@ -325,6 +402,12 @@ class ChatApplicationService:
                 enable_memory_retrieval=enable_memory_retrieval,
                 generation_options=generation_options,
             )
+
+            if run.outcome is ChatRunOutcome.STOP_REQUESTED:
+                raise _ChatRunCancelled(
+                    ChatRunPhase.PREPARE,
+                    run.stop_reason or "user_requested",
+                )
 
             prelude = prepared.stream_prelude
             yield {
@@ -337,21 +420,7 @@ class ChatApplicationService:
             }
             yield {"event": "memory_refs", "data": {"memories": prelude.memory_refs}}
 
-            # 分支：用户在 prepare 期间请求取消。跳过 Alice 和 finalize，返回 cancelled done。
-            if run.cancelled:
-                run.status = ChatGenerationRunStatus.CANCELLED
-                self._emit_chat_event(
-                    RuntimeEventType.CHAT_RUN_CANCELLED,
-                    run,
-                    trace_id=trace_id,
-                    agent_id=agent_id,
-                    topic_id=prelude.topic_id,
-                )
-                terminal_state = "cancelled"
-                yield self._cancelled_done(run)
-                return
-
-            run.status = ChatGenerationRunStatus.STREAMING
+            run.enter_phase(ChatRunPhase.ALICE)
             self._emit_chat_status(
                 run,
                 trace_id=trace_id,
@@ -359,26 +428,35 @@ class ChatApplicationService:
                 topic_id=prelude.topic_id,
             )
             loop_result = None
-            stream = await self._bus.request(
-                GlobalRoutes.ALICE_RUN_AGENT_STREAM,
-                agent_run_context=prepared.agent_run_context,
-                generation_options=prepared.generation_options,
-                cancel_event=run.cancel_event,
-                generation_id=run.generation_id,
+            stream = await _run_interruptible(
+                run,
+                ChatRunPhase.ALICE,
+                lambda: self._bus.request(
+                    GlobalRoutes.ALICE_RUN_AGENT_STREAM,
+                    agent_run_context=prepared.agent_run_context,
+                    generation_options=prepared.generation_options,
+                    generation_id=run.generation_id,
+                ),
             )
-            async for event in stream:
+            while True:
+                try:
+                    event = await _run_interruptible(
+                        run,
+                        ChatRunPhase.ALICE,
+                        lambda: anext(stream),
+                    )
+                except StopAsyncIteration:
+                    break
                 if event["event"] == "done":
                     loop_result = AgentRunResult(**event["data"])
                 else:
                     yield event
 
-            # 分支：Alice stream 非异常结束但没有终态 done，按协议错误进入 failed。
             if loop_result is None:
                 raise RuntimeError("Stream ended without done event")
 
-            # 分支：用户取消或 Alice 响应取消。跳过 finalize，不触发主动记忆生成。
-            if run.cancelled or loop_result.status == AgentRunStatus.CANCELLED.value:
-                run.status = ChatGenerationRunStatus.CANCELLED
+            if loop_result.status == AgentRunStatus.CANCELLED.value:
+                run.mark_cancelled()
                 self._emit_chat_event(
                     RuntimeEventType.CHAT_RUN_CANCELLED,
                     run,
@@ -390,7 +468,7 @@ class ChatApplicationService:
                 yield self._cancelled_done(run, loop_result)
                 return
             if loop_result.status == AgentRunStatus.FAILED.value:
-                run.status = ChatGenerationRunStatus.FAILED
+                run.mark_failed()
                 self._emit_chat_event(
                     RuntimeEventType.CHAT_RUN_FAILED,
                     run,
@@ -403,7 +481,11 @@ class ChatApplicationService:
                 yield self._failed_done(run, loop_result)
                 return
 
-            run.status = ChatGenerationRunStatus.FINALIZING
+            if not run.try_enter_finalizing():
+                raise _ChatRunCancelled(
+                    run.phase,
+                    run.stop_reason or "user_requested",
+                )
             self._emit_chat_status(
                 run,
                 trace_id=trace_id,
@@ -414,7 +496,7 @@ class ChatApplicationService:
                 "event": "run_status",
                 "data": {
                     "generation_id": run.generation_id,
-                    "status": run.status.value,
+                    "status": "finalizing",
                 },
             }
             # 分支：正常完成 Alice 后进入 Patchouli finalize；成功后 prepared 不再需要 cleanup。
@@ -427,7 +509,7 @@ class ChatApplicationService:
             memory_task_ids = [memory_task.task_id for memory_task in (memory_tasks or [])]
             final_pool_topics = await self._list_final_pool_topics(prepared)
 
-            run.status = ChatGenerationRunStatus.COMPLETED
+            run.mark_completed()
             self._emit_chat_event(
                 RuntimeEventType.CHAT_RUN_COMPLETED,
                 run,
@@ -450,21 +532,22 @@ class ChatApplicationService:
                 },
             }
 
-        except GatewayCancelledError:
-            run.status = ChatGenerationRunStatus.CANCELLED
+        except _ChatRunCancelled as cancelled:
+            run.mark_cancelled()
             self._emit_chat_event(
                 RuntimeEventType.CHAT_RUN_CANCELLED,
                 run,
                 trace_id=trace_id,
                 agent_id=agent_id,
+                topic_id=prepared.topic_id if prepared is not None else None,
+                data={"phase": cancelled.phase.value},
             )
             terminal_state = "cancelled"
             yield self._cancelled_done(run)
             return
         except Exception as e:
-            # 分支：prepare / Alice / finalize 任一阶段抛出非取消异常，统一发布 failed。
             logger.error(f"ChatApplicationService.chat_stream 异常: {e}", exc_info=True)
-            run.status = ChatGenerationRunStatus.FAILED
+            run.mark_failed()
             self._emit_chat_event(
                 RuntimeEventType.CHAT_RUN_FAILED,
                 run,
@@ -478,10 +561,11 @@ class ChatApplicationService:
             yield {"event": "error", "data": {"message": "系统错误，请检查后端服务器"}}
         finally:
             # 分支：客户端断开或生成器被提前关闭，且此前没有 completed/cancelled/failed 终态。
-            if terminal_state is None:
-                if not run.cancelled:
-                    run.request_cancel("stream_closed")
-                run.status = ChatGenerationRunStatus.CANCELLED
+            owner_is_cancelling = owner_task is not None and owner_task.cancelling() > 0
+            if terminal_state is None and not owner_is_cancelling:
+                if run.outcome is ChatRunOutcome.RUNNING:
+                    run.request_stop("stream_closed")
+                run.mark_cancelled()
                 self._emit_chat_event(
                     RuntimeEventType.CHAT_RUN_CANCELLED,
                     run,
@@ -489,7 +573,7 @@ class ChatApplicationService:
                     agent_id=agent_id,
                     topic_id=prepared.topic_id if prepared is not None else None,
                     message="Chat stream closed before terminal event.",
-                    data={"close_reason": run.cancel_reason or "stream_closed"},
+                    data={"close_reason": run.stop_reason or "stream_closed"},
                 )
                 terminal_state = "cancelled"
             # 统一清理：无论正常、取消、失败还是断流，都尝试关闭 Alice 子流。
@@ -509,7 +593,7 @@ class ChatApplicationService:
                     )
                 except Exception:
                     logger.warning("清理 prepared run 失败", exc_info=True)
-            self._registry.close(run.generation_id, run.status)
+            self._registry.close(run.generation_id)
             if tokens is not None:
                 reset_trace_context(tokens)
 
@@ -551,7 +635,7 @@ class ChatApplicationService:
                 "generation_id": run.generation_id,
                 "status": "cancelled",
                 "stopped": True,
-                "reason": run.cancel_reason or "user_requested",
+                "reason": run.stop_reason or "user_requested",
                 "memory_task_ids": [],
             },
         }
@@ -637,13 +721,26 @@ class ChatApplicationService:
                 generation_id=run.generation_id,
                 agent_id=agent_id,
                 topic_id=topic_id,
-                status=run.status.value,
-                reason=run.cancel_reason,
+                status=self._event_status(run),
+                reason=run.stop_reason,
                 severity=severity,  # type: ignore[arg-type]
                 message=message,
                 data=data or {},
             )
         )
+
+    @staticmethod
+    def _event_status(run: ChatGenerationRun) -> str:
+        if run.outcome is not ChatRunOutcome.RUNNING:
+            return run.outcome.value
+        return {
+            ChatRunPhase.CREATED: "created",
+            ChatRunPhase.GATEWAY: "preparing",
+            ChatRunPhase.PREPARE: "preparing",
+            ChatRunPhase.ALICE: "streaming",
+            ChatRunPhase.FINALIZE: "finalizing",
+            ChatRunPhase.TERMINAL: "terminal",
+        }[run.phase]
 
     async def _list_final_pool_topics(self, prepared_run) -> list[dict[str, Any]]:
         try:

--- a/src/hivememory/system/runtime/control.py
+++ b/src/hivememory/system/runtime/control.py
@@ -1,26 +1,45 @@
-"""Runtime control handles owned by the system application layer."""
+"""System 应用层持有的 Chat Run 运行时控制句柄。"""
 
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
 
 
-class ChatGenerationRunStatus(str, Enum):
+class ChatRunPhase(str, Enum):
+    """Chat Run 当前所在的编排阶段。"""
+
     CREATED = "created"
-    PREPARING = "preparing"
-    STREAMING = "streaming"
-    FINALIZING = "finalizing"
-    COMPLETED = "completed"
-    CANCELLING = "cancelling"
+    GATEWAY = "gateway"
+    PREPARE = "prepare"
+    ALICE = "alice"
+    FINALIZE = "finalize"
+    TERMINAL = "terminal"
+
+
+class ChatRunOutcome(str, Enum):
+    """Chat Run 的持久终态事实。"""
+
+    RUNNING = "running"
+    STOP_REQUESTED = "stop_requested"
     CANCELLED = "cancelled"
+    COMPLETED = "completed"
     FAILED = "failed"
 
 
-@dataclass
+@dataclass(frozen=True)
+class StopResult:
+    """一次 stop 请求的即时判定。"""
+
+    accepted: bool
+    reason: str
+
+
+@dataclass(frozen=True)
 class CancelResult:
+    """Stop API 对外保持的结构化结果。"""
+
     generation_id: str
     cancelled: bool
     status: str
@@ -29,29 +48,90 @@ class CancelResult:
 
 @dataclass
 class ChatGenerationRun:
+    """一次 Chat Run 的阶段引用与终态事实。"""
+
     generation_id: str
-    cancel_event: asyncio.Event = field(default_factory=asyncio.Event)
-    status: ChatGenerationRunStatus = ChatGenerationRunStatus.CREATED
-    cancel_reason: Optional[str] = None
+    phase: ChatRunPhase = ChatRunPhase.CREATED
+    outcome: ChatRunOutcome = ChatRunOutcome.RUNNING
+    stop_reason: str | None = None
+    active_task: asyncio.Task[object] | None = None
 
-    @property
-    def cancelled(self) -> bool:
-        return self.cancel_event.is_set()
+    def bind_phase(self, phase: ChatRunPhase, task: asyncio.Task[object]) -> None:
+        """绑定当前可被 stop 中断的阶段 task。"""
+        self.phase = phase
+        self.active_task = task
 
-    def request_cancel(self, reason: str = "user_requested") -> None:
-        if self.status not in (
-            ChatGenerationRunStatus.CANCELLED,
-            ChatGenerationRunStatus.COMPLETED,
-            ChatGenerationRunStatus.FAILED,
-        ):
-            self.status = ChatGenerationRunStatus.CANCELLING
-            if self.cancel_reason is None:
-                self.cancel_reason = reason
-        self.cancel_event.set()
+    def unbind_phase(self, task: asyncio.Task[object]) -> None:
+        """仅按 task 身份解绑，避免旧 task 清空新阶段引用。"""
+        if self.active_task is task:
+            self.active_task = None
+
+    def enter_phase(self, phase: ChatRunPhase) -> None:
+        """进入没有可中断 task 的阶段或阶段交接窗口。"""
+        self.phase = phase
+        self.active_task = None
+
+    def try_enter_finalizing(self) -> bool:
+        """同步进入 finalize；已接受 stop 时拒绝进入。"""
+        if self.outcome in {ChatRunOutcome.STOP_REQUESTED, ChatRunOutcome.CANCELLED}:
+            return False
+        if self.phase is ChatRunPhase.TERMINAL:
+            return False
+        self.phase = ChatRunPhase.FINALIZE
+        self.active_task = None
+        return True
+
+    def mark_cancelled(self) -> None:
+        """记录 Chat-level cancelled 终态。"""
+        self.outcome = ChatRunOutcome.CANCELLED
+        self.phase = ChatRunPhase.TERMINAL
+        self.active_task = None
+
+    def mark_completed(self) -> None:
+        """记录 Chat-level completed 终态。"""
+        self.outcome = ChatRunOutcome.COMPLETED
+        self.phase = ChatRunPhase.TERMINAL
+        self.active_task = None
+
+    def mark_failed(self) -> None:
+        """记录 Chat-level failed 终态。"""
+        self.outcome = ChatRunOutcome.FAILED
+        self.phase = ChatRunPhase.TERMINAL
+        self.active_task = None
+
+    def request_stop(self, reason: str = "user_requested") -> StopResult:
+        """同步记录 stop，并取消当前唯一的可中断阶段 task。"""
+        if self.outcome in {ChatRunOutcome.STOP_REQUESTED, ChatRunOutcome.CANCELLED}:
+            return StopResult(
+                accepted=True,
+                reason=self.stop_reason or reason,
+            )
+
+        if self.phase in {ChatRunPhase.FINALIZE, ChatRunPhase.TERMINAL}:
+            return StopResult(
+                accepted=False,
+                reason=(
+                    "already_finalizing"
+                    if self.phase is ChatRunPhase.FINALIZE
+                    else "already_terminal"
+                ),
+            )
+
+        self.outcome = ChatRunOutcome.STOP_REQUESTED
+        self.stop_reason = reason
+
+        task = self.active_task
+        if task is not None and not task.done():
+            task.cancel()
+
+        return StopResult(
+            accepted=True,
+            reason=reason,
+        )
 
 
 class ChatGenerationRunRegistry:
-    """In-process registry and cancellation surface for chat runs."""
+    """进程内 Chat Run 注册表与 stop API 控制面。"""
 
     def __init__(self) -> None:
         self._runs: dict[str, ChatGenerationRun] = {}
@@ -59,7 +139,7 @@ class ChatGenerationRunRegistry:
     def register(self, run: ChatGenerationRun) -> None:
         self._runs[run.generation_id] = run
 
-    def get(self, generation_id: str) -> Optional[ChatGenerationRun]:
+    def get(self, generation_id: str) -> ChatGenerationRun | None:
         return self._runs.get(generation_id)
 
     def cancel(self, generation_id: str, reason: str = "user_requested") -> CancelResult:
@@ -71,23 +151,25 @@ class ChatGenerationRunRegistry:
                 status="not_found",
                 reason=reason,
             )
-        run.request_cancel(reason)
+
+        result = run.request_stop(reason)
         return CancelResult(
             generation_id=generation_id,
-            cancelled=True,
-            status=run.status.value,
-            reason=run.cancel_reason or reason,
+            cancelled=result.accepted,
+            status=run.outcome.value,
+            reason=result.reason,
         )
 
-    def close(self, generation_id: str, status: ChatGenerationRunStatus) -> None:
-        run = self._runs.pop(generation_id, None)
-        if run is not None and not run.cancelled:
-            run.status = status
+    def close(self, generation_id: str) -> None:
+        """移除已由 Chat application 记录终态的 run。"""
+        self._runs.pop(generation_id, None)
 
 
 __all__ = [
     "CancelResult",
     "ChatGenerationRun",
     "ChatGenerationRunRegistry",
-    "ChatGenerationRunStatus",
+    "ChatRunOutcome",
+    "ChatRunPhase",
+    "StopResult",
 ]

--- a/tests/unit/agent_runtime/execution/test_loop_stream.py
+++ b/tests/unit/agent_runtime/execution/test_loop_stream.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -33,16 +34,52 @@ class RecordingFrameOutputSink:
         self.outputs.append(output)
 
 
+class TrackingChunkStream:
+    """记录 AgentLoop 是否显式关闭其消费的 Worker stream。"""
+
+    def __init__(
+        self,
+        chunks: list[StreamChunk] | None = None,
+        *,
+        block_after_chunks: bool = False,
+        close_error: Exception | None = None,
+    ) -> None:
+        self._chunks = list(chunks or [])
+        self._block_after_chunks = block_after_chunks
+        self._close_error = close_error
+        self.pull_started = asyncio.Event()
+        self.close_calls = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> StreamChunk:
+        if self._chunks:
+            return self._chunks.pop(0)
+        if self._block_after_chunks:
+            self.pull_started.set()
+            await asyncio.Event().wait()
+        raise StopAsyncIteration
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+        if self._close_error is not None:
+            raise self._close_error
+
+
 @pytest.mark.asyncio
 async def test_stream_sink_receives_typed_token_outputs_in_order() -> None:
-    async def generate_stream(_messages, **_kwargs):
-        yield StreamChunk(delta="partial", full_text="partial")
-        yield StreamChunk(
-            is_final=True,
-            result=GenerationResult(text="complete", finish_reason="stop"),
-        )
+    stream = TrackingChunkStream(
+        [
+            StreamChunk(delta="partial", full_text="partial"),
+            StreamChunk(
+                is_final=True,
+                result=GenerationResult(text="complete", finish_reason="stop"),
+            ),
+        ]
+    )
 
-    worker_agent = MagicMock(generate_stream=generate_stream)
+    worker_agent = MagicMock(generate_stream=MagicMock(return_value=stream))
     executor = AgentLoopExecutor(
         worker_agent=worker_agent,
         mtp_executor=MagicMock(),
@@ -54,6 +91,88 @@ async def test_stream_sink_receives_typed_token_outputs_in_order() -> None:
 
     assert result.status == FrameExecutionStatus.COMPLETED
     assert sink.outputs == [TokenDelta(content="partial")]
+    assert stream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_is_closed_when_output_sink_fails() -> None:
+    class FailingFrameOutputSink:
+        streams_tokens = True
+
+        async def send(self, output: FrameOutput) -> None:
+            raise RuntimeError("sink failed")
+
+    stream = TrackingChunkStream([StreamChunk(delta="partial", full_text="partial")])
+    worker_agent = MagicMock(generate_stream=MagicMock(return_value=stream))
+    executor = AgentLoopExecutor(
+        worker_agent=worker_agent,
+        mtp_executor=MagicMock(),
+        config=MagicMock(max_loop_iterations=2),
+    )
+
+    with pytest.raises(RuntimeError, match="sink failed"):
+        await executor.execute_frame(
+            _frame(),
+            max_iterations=2,
+            output_sink=FailingFrameOutputSink(),
+        )
+
+    assert stream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_is_closed_when_pull_task_is_cancelled() -> None:
+    stream = TrackingChunkStream(block_after_chunks=True)
+    worker_agent = MagicMock(generate_stream=MagicMock(return_value=stream))
+    executor = AgentLoopExecutor(
+        worker_agent=worker_agent,
+        mtp_executor=MagicMock(),
+        config=MagicMock(max_loop_iterations=2),
+    )
+
+    task = asyncio.create_task(
+        executor.execute_frame(
+            _frame(),
+            max_iterations=2,
+            output_sink=RecordingFrameOutputSink(),
+        )
+    )
+    await stream.pull_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert stream.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_close_error_does_not_replace_task_cancellation() -> None:
+    stream = TrackingChunkStream(
+        block_after_chunks=True,
+        close_error=RuntimeError("close failed"),
+    )
+    worker_agent = MagicMock(generate_stream=MagicMock(return_value=stream))
+    executor = AgentLoopExecutor(
+        worker_agent=worker_agent,
+        mtp_executor=MagicMock(),
+        config=MagicMock(max_loop_iterations=2),
+    )
+
+    task = asyncio.create_task(
+        executor.execute_frame(
+            _frame(),
+            max_iterations=2,
+            output_sink=RecordingFrameOutputSink(),
+        )
+    )
+    await stream.pull_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert stream.close_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/agent_runtime/execution/test_loop_turn_events.py
+++ b/tests/unit/agent_runtime/execution/test_loop_turn_events.py
@@ -303,43 +303,47 @@ async def test_mtp_execution_receives_frame_context():
 
 
 @pytest.mark.asyncio
-async def test_cancel_before_mtp_execution_skips_executor():
+async def test_task_cancellation_during_generation_propagates_before_mtp():
     frame = _make_frame()
-    cancel_event = asyncio.Event()
+    started = asyncio.Event()
 
-    async def generate_and_cancel(*args, **kwargs):
-        cancel_event.set()
-        return _mtp_result("前缀", "<< READ | alias_x >>")
+    async def slow_generate(*args, **kwargs):
+        started.set()
+        await asyncio.Event().wait()
 
     executor, _kernel = _build_executor([])
-    executor.worker_agent.generate_async = AsyncMock(side_effect=generate_and_cancel)
+    executor.worker_agent.generate_async = slow_generate
 
-    await executor.execute_frame(frame, max_iterations=5, cancel_event=cancel_event)
+    task = asyncio.create_task(executor.execute_frame(frame, max_iterations=5))
+    await started.wait()
+    task.cancel()
 
+    with pytest.raises(asyncio.CancelledError):
+        await task
     executor._mtp_executor.intercept_and_execute.assert_not_awaited()
-    assert "".join(frame.progress.text_segments) == "前缀"
-    assert [ev.kind for ev in frame.progress.turn_events] == ["assistant_message"]
 
 
 @pytest.mark.asyncio
-async def test_cancel_after_mtp_execution_skips_result_processing():
+async def test_task_cancellation_during_mtp_propagates():
     frame = _make_frame()
     gen_results = [_mtp_result("前缀", "<< READ | alias_x >>")]
     executor, _kernel = _build_executor(gen_results)
-    cancel_event = asyncio.Event()
+    started = asyncio.Event()
 
-    async def execute_and_cancel(*args, **kwargs):
-        cancel_event.set()
-        return _mtp_exec_result("READ")
+    async def slow_execute(*args, **kwargs):
+        started.set()
+        await asyncio.Event().wait()
 
-    executor._mtp_executor.intercept_and_execute = AsyncMock(side_effect=execute_and_cancel)
+    executor._mtp_executor.intercept_and_execute = slow_execute
 
-    await executor.execute_frame(frame, max_iterations=5, cancel_event=cancel_event)
+    task = asyncio.create_task(executor.execute_frame(frame, max_iterations=5))
+    await started.wait()
+    task.cancel()
 
-    executor._mtp_executor.intercept_and_execute.assert_awaited_once()
+    with pytest.raises(asyncio.CancelledError):
+        await task
     assert "".join(frame.progress.text_segments) == "前缀"
     assert [ev.kind for ev in frame.progress.turn_events] == ["assistant_message"]
-    assert len(frame.working_history) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/agent_runtime/execution/test_worker.py
+++ b/tests/unit/agent_runtime/execution/test_worker.py
@@ -223,6 +223,25 @@ class _MockStreamResponse:
             yield item
 
 
+class _CloseFailingStreamResponse:
+    """模拟取消期间底层 LLM response 关闭失败。"""
+
+    def __init__(self) -> None:
+        self.pull_started = asyncio.Event()
+        self.close_calls = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        self.pull_started.set()
+        await asyncio.Event().wait()
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+        raise RuntimeError("response close failed")
+
+
 def _make_stream_chunk(delta: str = "", finish_reason=None):
     choice = Mock()
     choice.delta.content = delta
@@ -236,6 +255,28 @@ def _make_stream_chunk(delta: str = "", finish_reason=None):
 class TestWorkerAgentGenerateStream:
     def setup_method(self):
         self.service = WorkerAgentService()
+
+    @patch("hivememory.agent_runtime.execution.worker.litellm.acompletion")
+    async def test_response_close_error_does_not_replace_task_cancellation(
+        self,
+        mock_completion,
+    ):
+        response = _CloseFailingStreamResponse()
+        mock_completion.return_value = response
+        chunks = self.service.generate_stream(
+            [{"role": "user", "content": "hi"}],
+            model="test-model",
+            api_key="test-key",
+        ).__aiter__()
+
+        pull_task = asyncio.create_task(anext(chunks))
+        await response.pull_started.wait()
+        pull_task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await pull_task
+
+        assert response.close_calls == 1
 
     @patch("hivememory.agent_runtime.execution.worker.litellm.acompletion")
     async def test_stream_no_duplicate_before_mtp(self, mock_completion):

--- a/tests/unit/agent_runtime/execution/test_worker.py
+++ b/tests/unit/agent_runtime/execution/test_worker.py
@@ -7,9 +7,10 @@ WorkerAgentService 单元测试
 - 异常传播 / stop sequence 注入 / kwargs 透传
 """
 
-import pytest
 import asyncio
 from unittest.mock import Mock, patch
+
+import pytest
 
 from hivememory.agent_runtime.execution.worker import WorkerAgentService
 from hivememory.core.mtp import MTP_LEFT_DELIMITER, MTP_RIGHT_DELIMITER, MTP_STOP_SEQUENCE
@@ -182,32 +183,32 @@ class TestWorkerAgentGenerateAsync:
         assert call_kwargs["presence_penalty"] == 0.5
 
     @patch("hivememory.agent_runtime.execution.worker.litellm.acompletion")
-    async def test_cancel_event_cancels_completion(self, mock_completion):
-        """非流式 LLM 调用期间 cancel_event 触发时返回 cancelled。"""
+    async def test_task_cancellation_propagates_from_completion(self, mock_completion):
+        """非流式 LLM 调用期间 task cancellation 原样向上传播。"""
         started = asyncio.Event()
-        release = asyncio.Event()
+        provider_cancelled = asyncio.Event()
 
         async def slow_completion(**kwargs):
             started.set()
-            await release.wait()
-            return _make_response("late", "stop")
+            try:
+                await asyncio.Event().wait()
+            finally:
+                provider_cancelled.set()
 
         mock_completion.side_effect = slow_completion
-        cancel_event = asyncio.Event()
         task = asyncio.create_task(
             self.service.generate_async(
                 [{"role": "user", "content": "test"}],
-                cancel_event=cancel_event,
                 model="test-model", api_key="test-key",
             )
         )
 
         await started.wait()
-        cancel_event.set()
-        result = await task
+        task.cancel()
 
-        assert result.finish_reason == "cancelled"
-        assert result.text == ""
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert provider_cancelled.is_set()
 
 
 class _MockStreamResponse:

--- a/tests/unit/agent_runtime/mtp/test_executor.py
+++ b/tests/unit/agent_runtime/mtp/test_executor.py
@@ -32,6 +32,5 @@ async def test_koakuma_mtp_executor_delegates_to_runtime():
     koakuma.intercept_and_execute.assert_awaited_once_with(
         "assistant text",
         context=context,
-        cancel_event=None,
     )
     assert actual is result

--- a/tests/unit/alice/application/test_agent_run_result.py
+++ b/tests/unit/alice/application/test_agent_run_result.py
@@ -121,25 +121,29 @@ async def test_run_agent_assembles_result_from_completed_frame():
 
 
 @pytest.mark.asyncio
-async def test_run_agent_cancelled_does_not_materialize_runtime_products():
+async def test_run_agent_cancellation_unwinds_and_propagates():
     frame = _frame()
-    cancel_event = asyncio.Event()
-    cancel_event.set()
-    session = RunSession(agent_run_id="run-1", cancel_event=cancel_event)
+    started = asyncio.Event()
+
+    async def run_frame(*_args, **_kwargs):
+        started.set()
+        await asyncio.Event().wait()
+
     agent_runtime = SimpleNamespace(
         max_iterations=5,
-        run_frame=AsyncMock(
-            return_value=FrameExecutionResult(status=FrameExecutionStatus.COMPLETED)
-        ),
+        run_frame=run_frame,
         finalize_run=MagicMock(return_value=RuntimeProducts()),
         finalize_frame=MagicMock(return_value=FrameProducts()),
     )
-    service, _ = _runtime_for_frame(frame, agent_runtime, session=session)
+    service, _ = _runtime_for_frame(frame, agent_runtime)
 
-    result = await service.run_agent(_context(frame))
+    task = asyncio.create_task(service.run_agent(_context(frame)))
+    await started.wait()
+    task.cancel()
 
-    assert result.status == AgentRunStatus.CANCELLED.value
-    assert result.materialize_tasks == []
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    agent_runtime.finalize_run.assert_called_once()
     assert agent_runtime.finalize_run.call_args.args[1].status == FrameExecutionStatus.CANCELLED
 
 

--- a/tests/unit/alice/application/test_agent_run_service.py
+++ b/tests/unit/alice/application/test_agent_run_service.py
@@ -194,6 +194,59 @@ async def test_run_agent_stream_close_emits_cancelled_runtime_event():
 
 
 @pytest.mark.asyncio
+async def test_executor_stream_close_error_does_not_replace_task_cancellation():
+    recorder = RecordingRuntimeEventSink()
+    _runtime, service = _build_service(runtime_events=recorder)
+    context = _build_agent_run_context(_build_memory_atom())
+
+    class CloseFailingExecutorStream:
+        def __init__(self) -> None:
+            self._emitted = False
+            self.pull_started = asyncio.Event()
+            self.close_calls = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._emitted:
+                self.pull_started.set()
+                await asyncio.Event().wait()
+            self._emitted = True
+            return {"event": "token", "data": {"content": "hi"}}
+
+        async def aclose(self) -> None:
+            self.close_calls += 1
+            raise RuntimeError("executor stream close failed")
+
+    executor_stream = CloseFailingExecutorStream()
+    agent_stream = MagicMock()
+    agent_stream.output = MagicMock()
+
+    def events(runner):
+        runner.close()
+        return executor_stream
+
+    agent_stream.events.side_effect = events
+    service._stream_adapter.create = MagicMock(return_value=agent_stream)
+    stream = service.run_agent_stream(context)
+
+    assert (await anext(stream))["event"] == "token"
+    pull_task = asyncio.create_task(anext(stream))
+    await executor_stream.pull_started.wait()
+    pull_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await pull_task
+
+    assert executor_stream.close_calls == 1
+    assert recorder.events[-1].event_type == RuntimeEventType.AGENT_RUN_CANCELLED
+    assert RuntimeEventType.AGENT_RUN_FAILED not in {
+        event.event_type for event in recorder.events
+    }
+
+
+@pytest.mark.asyncio
 async def test_run_agent_stream_error_preserves_failed_runtime_event():
     recorder = RecordingRuntimeEventSink()
     runtime, service = _build_service(runtime_events=recorder)

--- a/tests/unit/alice/application/test_agent_run_service.py
+++ b/tests/unit/alice/application/test_agent_run_service.py
@@ -127,11 +127,8 @@ async def test_run_agent_correlates_runtime_scope_and_generation_id():
         return session
 
     service._create_run_session = _capture_session
-    cancel_event = asyncio.Event()
-
     await service.run_agent(
         context,
-        cancel_event=cancel_event,
         generation_id="generation-1",
     )
 
@@ -139,8 +136,6 @@ async def test_run_agent_correlates_runtime_scope_and_generation_id():
     assert session.generation_id == "generation-1"
     assert session.agent_run_id == recorder.events[0].agent_run_id
     assert recorder.events[0].generation_id == "generation-1"
-    assert session.cancel_event is cancel_event
-    assert runtime._agent_runtime.run_frame.await_args.kwargs["cancel_event"] is cancel_event
 
 
 @pytest.mark.asyncio
@@ -179,10 +174,7 @@ async def test_run_agent_stream_close_emits_cancelled_runtime_event():
     recorder = RecordingRuntimeEventSink()
     runtime, service = _build_service(runtime_events=recorder)
     context = _build_agent_run_context(_build_memory_atom())
-    received_cancel_events = []
-
-    async def _run_frame(_frame, *, output_sink, cancel_event, **_kwargs):
-        received_cancel_events.append(cancel_event)
+    async def _run_frame(_frame, *, output_sink, **_kwargs):
         await output_sink.send(TokenDelta(content="hi"))
         await asyncio.Event().wait()
 
@@ -198,24 +190,20 @@ async def test_run_agent_stream_close_emits_cancelled_runtime_event():
     assert RuntimeEventType.AGENT_RUN_CANCELLED in runtime_event_types
     assert recorder.events[-1].status == "cancelled"
     assert recorder.events[-1].data["close_reason"] == "stream_closed"
-    assert len(received_cancel_events) == 1
-    assert received_cancel_events[0].is_set()
     runtime._agent_runtime.finalize_run.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_run_agent_stream_error_does_not_set_cancel_event():
+async def test_run_agent_stream_error_preserves_failed_runtime_event():
     recorder = RecordingRuntimeEventSink()
     runtime, service = _build_service(runtime_events=recorder)
     context = _build_agent_run_context(_build_memory_atom())
-    cancel_event = asyncio.Event()
     runtime._agent_runtime.run_frame = AsyncMock(side_effect=RuntimeError("network unavailable"))
 
     with pytest.raises(RuntimeError, match="network unavailable"):
-        async for _ in service.run_agent_stream(context, cancel_event=cancel_event):
+        async for _ in service.run_agent_stream(context):
             pass
 
-    assert cancel_event.is_set() is False
     assert recorder.events[-1].event_type == RuntimeEventType.AGENT_RUN_FAILED
     assert recorder.events[-1].status == "failed"
 
@@ -225,8 +213,6 @@ async def test_run_agent_stream_without_executor_terminal_fails_cleanly():
     recorder = RecordingRuntimeEventSink()
     _runtime, service = _build_service(runtime_events=recorder)
     context = _build_agent_run_context(_build_memory_atom())
-    cancel_event = asyncio.Event()
-
     executor = MagicMock()
     executor.run = AsyncMock(
         return_value=FrameExecutionResult(status=FrameExecutionStatus.COMPLETED)
@@ -237,9 +223,8 @@ async def test_run_agent_stream_without_executor_terminal_fails_cleanly():
         return_value=executor,
     ):
         with pytest.raises(RuntimeError, match="ended without done"):
-            async for _ in service.run_agent_stream(context, cancel_event=cancel_event):
+            async for _ in service.run_agent_stream(context):
                 pass
 
-    assert cancel_event.is_set() is False
     assert recorder.events[-1].event_type == RuntimeEventType.AGENT_RUN_FAILED
     assert recorder.events[-1].message == "Agent stream ended without done event."

--- a/tests/unit/alice/orchestration/sub_agent/test_call_coordinator.py
+++ b/tests/unit/alice/orchestration/sub_agent/test_call_coordinator.py
@@ -15,7 +15,6 @@ from hivememory.alice.orchestration.run_session import RunSession
 from hivememory.alice.orchestration.sub_agent.call_context_provider import CallContext
 from hivememory.alice.orchestration.sub_agent.call_coordinator import (
     CallCoordinator,
-    CancelRun,
     DispatchCallee,
     ResumeCaller,
 )
@@ -78,11 +77,8 @@ def _coordinator(runtime, child: ExecutionFrame, *, context_provider=None) -> Ca
     )
 
 
-def _session(caller: ExecutionFrame, *, cancel_event: asyncio.Event | None = None) -> RunSession:
-    session = RunSession(
-        agent_run_id=caller.runtime_scope.run_id,
-        cancel_event=cancel_event if cancel_event is not None else asyncio.Event(),
-    )
+def _session(caller: ExecutionFrame) -> RunSession:
+    session = RunSession(agent_run_id=caller.runtime_scope.run_id)
     session.register_frame(caller)
     return session
 
@@ -140,12 +136,11 @@ def test_call_record_cancel_wins_before_apply():
         record.mark_applied()
 
 
-def test_call_results_express_dispatch_resume_and_cancel_without_nullable_payloads():
+def test_call_results_express_dispatch_and_resume_without_nullable_payloads():
     caller = _frame()
 
     assert DispatchCallee(caller).frame is caller
     assert ResumeCaller() == ResumeCaller()
-    assert CancelRun() == CancelRun()
 
 
 @pytest.mark.asyncio
@@ -198,7 +193,7 @@ async def test_begin_and_complete_call_split_execution_from_coordination_phases(
 
 
 @pytest.mark.asyncio
-async def test_cancel_call_finalizes_bound_child_and_applies_cancelled_response_once():
+async def test_cancel_call_finalizes_bound_child_and_marks_record_once():
     caller = _frame()
     child = _frame()
     child.runtime_scope = child.runtime_scope.model_copy(update={"frame_id": "frame-child"})
@@ -213,17 +208,14 @@ async def test_cancel_call_finalizes_bound_child_and_applies_cancelled_response_
     begin = await coordinator.begin_call(caller, suspension, session=session)
     assert begin == DispatchCallee(child)
 
-    session.cancel_event.set()
     coordinator.cancel_call(caller, suspension, session=session)
     coordinator.cancel_call(caller, suspension, session=session)
 
     runtime.finalize_frame.assert_called_once()
     assert runtime.finalize_frame.call_args.args[0] is child
     assert runtime.finalize_frame.call_args.args[1].status == FrameExecutionStatus.CANCELLED
-    runtime.apply_call_response.assert_called_once()
-    response = runtime.apply_call_response.call_args.args[2]
-    assert response.status == MTPResponseStatus.CANCELLED
-    assert session.call_for_callee("frame-child").status == CallRecordStatus.APPLIED
+    runtime.apply_call_response.assert_not_called()
+    assert session.call_for_callee("frame-child").status == CallRecordStatus.CANCELLED
 
 
 @pytest.mark.asyncio
@@ -262,46 +254,6 @@ async def test_call_coordinator_finalizes_completed_child_without_finalizing_run
     runtime.finalize_run.assert_not_called()
     runtime.run_frame.assert_not_awaited()
     assert session.frames["frame-child"] is child
-    assert session.call_for_callee("frame-child").status == CallRecordStatus.APPLIED
-
-
-@pytest.mark.asyncio
-async def test_call_coordinator_cleans_late_success_when_cancel_wins():
-    caller = _frame()
-    child = _frame()
-    child.runtime_scope = child.runtime_scope.model_copy(update={"frame_id": "frame-child"})
-    child_result = FrameExecutionResult(status=FrameExecutionStatus.COMPLETED)
-    cancel_event = asyncio.Event()
-    runtime = SimpleNamespace(
-        max_iterations=8,
-        run_frame=AsyncMock(return_value=child_result),
-        finalize_frame=MagicMock(return_value=FrameProducts()),
-        finalize_run=MagicMock(),
-    )
-    coordinator = _coordinator(runtime, child)
-    session = _session(caller, cancel_event=cancel_event)
-
-    suspension = _suspension()
-    begin = await coordinator.begin_call(caller, suspension, session=session)
-    assert begin == DispatchCallee(child)
-    cancel_event.set()
-    transition = await coordinator.complete_call(
-        caller,
-        suspension,
-        child,
-        child_result,
-        session=session,
-    )
-
-    assert transition == CancelRun()
-    runtime.apply_call_response.assert_called_once()
-    response = runtime.apply_call_response.call_args.args[2]
-    assert response.status == MTPResponseStatus.CANCELLED
-    runtime.finalize_frame.assert_called_once()
-    assert runtime.finalize_frame.call_args.args[0] is child
-    assert runtime.finalize_frame.call_args.args[1].status == FrameExecutionStatus.CANCELLED
-    runtime.finalize_run.assert_not_called()
-    runtime.run_frame.assert_not_awaited()
     assert session.call_for_callee("frame-child").status == CallRecordStatus.APPLIED
 
 
@@ -368,7 +320,6 @@ async def test_call_response_is_committed_before_finished_output_await():
             run_output=output,
         )
 
-    session.cancel_event.set()
     coordinator.cancel_call(caller, suspension, session=session)
     runtime.apply_call_response.assert_called_once()
 
@@ -405,7 +356,6 @@ async def test_preparation_error_is_committed_before_finished_output_await():
             run_output=output,
         )
 
-    session.cancel_event.set()
     coordinator.cancel_call(caller, suspension, session=session)
     runtime.apply_call_response.assert_called_once()
 

--- a/tests/unit/alice/orchestration/test_parent_child_executor_baseline.py
+++ b/tests/unit/alice/orchestration/test_parent_child_executor_baseline.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import asyncio
 import logging
 from pathlib import Path
 from types import SimpleNamespace
@@ -22,7 +21,6 @@ from hivememory.alice.orchestration.run_session import RunSession
 from hivememory.alice.orchestration.sub_agent.call_context_provider import CallContext
 from hivememory.alice.orchestration.sub_agent.call_coordinator import (
     CallCoordinator,
-    CancelRun,
     DispatchCallee,
     ResumeCaller,
 )
@@ -50,11 +48,8 @@ def _suspension() -> FrameExecutionResult:
     )
 
 
-def _session(frame: ExecutionFrame, *, cancel_event: asyncio.Event | None = None) -> RunSession:
-    session = RunSession(
-        agent_run_id=frame.runtime_scope.run_id,
-        cancel_event=cancel_event if cancel_event is not None else asyncio.Event(),
-    )
+def _session(frame: ExecutionFrame) -> RunSession:
+    session = RunSession(agent_run_id=frame.runtime_scope.run_id)
     session.register_root_frame(frame)
     return session
 
@@ -231,43 +226,6 @@ async def test_artifact_harvest_failure_becomes_stable_call_error_and_cleans_chi
     assert runtime.finalize_frame.call_count == 2
     cleanup_result = runtime.finalize_frame.call_args.args[1]
     assert cleanup_result.status == FrameExecutionStatus.FAILED
-
-
-@pytest.mark.asyncio
-async def test_cancelled_session_stops_call_before_dispatch():
-    caller = _frame()
-    child = _frame("frame-child")
-    cancel_event = asyncio.Event()
-    cancel_event.set()
-
-    async def run_frame(frame, *, cancel_event: asyncio.Event, **_kwargs):
-        del frame
-        assert cancel_event is _session_cancel_event
-        assert cancel_event.is_set()
-        return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
-
-    _session_cancel_event = cancel_event
-    runtime = SimpleNamespace(
-        max_iterations=8,
-        run_frame=AsyncMock(side_effect=run_frame),
-        finalize_frame=MagicMock(return_value=FrameProducts()),
-    )
-    coordinator = _coordinator(runtime, child)
-
-    suspension = _suspension()
-    session = _session(caller, cancel_event=cancel_event)
-    begin = await coordinator.begin_call(
-        caller,
-        suspension,
-        session=session,
-    )
-    assert begin == CancelRun()
-    runtime.apply_call_response.assert_called_once()
-    response = runtime.apply_call_response.call_args.args[2]
-    assert response.status == MTPResponseStatus.CANCELLED
-    runtime.run_frame.assert_not_awaited()
-    runtime.finalize_frame.assert_not_called()
-    assert session.call_records[("frame-root", "action-1")].status.value == "applied"
 
 
 def test_run_executor_is_the_only_alice_run_frame_caller():

--- a/tests/unit/alice/orchestration/test_run_executor.py
+++ b/tests/unit/alice/orchestration/test_run_executor.py
@@ -13,7 +13,6 @@ from hivememory.alice.orchestration.run_executor import RunExecutor
 from hivememory.alice.orchestration.run_output import CallOutputFinished
 from hivememory.alice.orchestration.run_session import RunSession
 from hivememory.alice.orchestration.sub_agent.call_coordinator import (
-    CancelRun,
     DispatchCallee,
     ResumeCaller,
 )
@@ -21,11 +20,8 @@ from hivememory.alice.runtime.streaming import AgentRunStream, QueueAgentRunOutp
 from hivememory.core.mtp import MTPCallRequest
 
 
-def _session_with(frame, *, cancel_event: asyncio.Event | None = None) -> RunSession:
-    session = RunSession(
-        agent_run_id=frame.runtime_scope.run_id,
-        cancel_event=cancel_event if cancel_event is not None else asyncio.Event(),
-    )
+def _session_with(frame) -> RunSession:
+    session = RunSession(agent_run_id=frame.runtime_scope.run_id)
     session.register_root_frame(frame)
     return session
 
@@ -42,11 +38,9 @@ class _CallCoordinatorStub:
     def __init__(
         self,
         *,
-        cancel_on_complete: bool = False,
         emit_end: bool = False,
         child_ids: dict[str, str] | None = None,
     ) -> None:
-        self.cancel_on_complete = cancel_on_complete
         self.emit_end = emit_end
         self.child_ids = child_ids or {}
         self.callee_results = []
@@ -88,10 +82,6 @@ class _CallCoordinatorStub:
                     terminal_status="completed",
                 )
             )
-        if self.cancel_on_complete:
-            session.cancel_event.set()
-            record.cancel()
-            return CancelRun()
         record.mark_applied()
         return ResumeCaller()
 
@@ -328,7 +318,6 @@ async def test_run_executor_cleans_active_call_when_stream_consumer_closes():
     await stream.aclose()
 
     assert coordinator.cancel_calls == 1
-    assert session.cancel_event.is_set()
     assert session.call_records[("frame-1", "act-1")].status.value == "cancelled"
     finalize_run.assert_called_once()
     assert finalize_run.call_args.args[1].status == FrameExecutionStatus.CANCELLED
@@ -401,40 +390,6 @@ async def test_run_executor_accepts_call_resume_without_applying_response_itself
 
     assert result.status == FrameExecutionStatus.COMPLETED
     runtime.apply_call_response.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_run_executor_drops_late_call_response_after_cancel():
-    cancel_event = asyncio.Event()
-    applied = []
-
-    async def run_frame(current_frame, **_kwargs):
-        if current_frame.runtime_scope.frame_id == "frame-child":
-            return FrameExecutionResult(status=FrameExecutionStatus.COMPLETED)
-        if cancel_event.is_set():
-            return FrameExecutionResult(status=FrameExecutionStatus.CANCELLED)
-        return FrameExecutionResult(
-            status=FrameExecutionStatus.SUSPENDED,
-            call_request=MTPCallRequest(target_alias="helper", task="task"),
-            suspend_action_id="act-1",
-        )
-
-    runtime = SimpleNamespace(
-        run_frame=run_frame,
-        apply_call_response=lambda *args: applied.append(args),
-    )
-    frame = _frame_stub("frame-1")
-    session = _session_with(frame, cancel_event=cancel_event)
-    executor = RunExecutor(
-        runtime,
-        session=session,
-        call_coordinator=_CallCoordinatorStub(cancel_on_complete=True),
-    )
-
-    result = await executor.run(frame)
-
-    assert result.status == FrameExecutionStatus.CANCELLED
-    assert applied == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/alice/orchestration/test_run_executor.py
+++ b/tests/unit/alice/orchestration/test_run_executor.py
@@ -259,6 +259,108 @@ async def test_run_executor_cancellation_unwinds_each_nested_call_once():
 
 
 @pytest.mark.asyncio
+async def test_run_executor_preserves_cancellation_when_run_cleanup_fails():
+    started = asyncio.Event()
+
+    async def run_frame(_frame, **_kwargs):
+        started.set()
+        await asyncio.Event().wait()
+
+    finalize_run = MagicMock(side_effect=RuntimeError("run cleanup failed"))
+    frame = _frame_stub("frame-1")
+    executor = RunExecutor(
+        SimpleNamespace(run_frame=run_frame, finalize_run=finalize_run),
+        session=_session_with(frame),
+    )
+    task = asyncio.create_task(executor.run(frame))
+
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert executor.terminal_result is not None
+    assert executor.terminal_result.status == FrameExecutionStatus.CANCELLED
+    finalize_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_executor_still_finalizes_when_call_record_cleanup_fails():
+    started = asyncio.Event()
+
+    async def run_frame(_frame, **_kwargs):
+        started.set()
+        await asyncio.Event().wait()
+
+    frame = _frame_stub("frame-1")
+    session = _session_with(frame)
+    session.cancel_unapplied_calls = MagicMock(
+        side_effect=RuntimeError("record cleanup failed")
+    )
+    finalize_run = MagicMock()
+    executor = RunExecutor(
+        SimpleNamespace(run_frame=run_frame, finalize_run=finalize_run),
+        session=session,
+    )
+    task = asyncio.create_task(executor.run(frame))
+
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert executor.terminal_result is not None
+    assert executor.terminal_result.status == FrameExecutionStatus.CANCELLED
+    finalize_run.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_run_executor_preserves_cancellation_when_call_cleanup_fails():
+    preparation_started = asyncio.Event()
+
+    class FailingCancellationCoordinator(_CallCoordinatorStub):
+        async def begin_call(self, caller, suspension, *, session, **_kwargs):
+            record = session.register_call(caller, suspension.suspend_action_id)
+            record.begin_resolution()
+            preparation_started.set()
+            await asyncio.Event().wait()
+
+        def cancel_call(self, caller, suspension, *, session):
+            self.cancel_calls += 1
+            raise RuntimeError("call cleanup failed")
+
+    async def run_frame(_frame, **_kwargs):
+        return FrameExecutionResult(
+            status=FrameExecutionStatus.SUSPENDED,
+            call_request=MTPCallRequest(target_alias="helper", task="task"),
+            suspend_action_id="act-1",
+        )
+
+    frame = _frame_stub("frame-1")
+    session = _session_with(frame)
+    coordinator = FailingCancellationCoordinator()
+    executor = RunExecutor(
+        SimpleNamespace(run_frame=run_frame, finalize_run=MagicMock()),
+        session=session,
+        call_coordinator=coordinator,
+    )
+    task = asyncio.create_task(executor.run(frame))
+
+    await preparation_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert coordinator.cancel_calls == 1
+    assert session.call_records[("frame-1", "act-1")].status.value == "cancelled"
+    assert executor.terminal_result is not None
+    assert executor.terminal_result.status == FrameExecutionStatus.CANCELLED
+
+
+@pytest.mark.asyncio
 async def test_run_executor_cancels_runner_when_stream_consumer_closes():
     runner_cancelled = asyncio.Event()
 

--- a/tests/unit/alice/orchestration/test_run_session.py
+++ b/tests/unit/alice/orchestration/test_run_session.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from hivememory.agent_runtime.models import ExecutionFrame
@@ -63,8 +61,7 @@ def test_callee_policy_removes_call_without_reading_frame_depth() -> None:
     assert not policy.allows("CALL")
 
 
-@pytest.mark.asyncio
-async def test_interleaved_sessions_keep_cancel_and_records_isolated() -> None:
+def test_interleaved_sessions_keep_records_isolated() -> None:
     session_a = RunSession(agent_run_id="run-a")
     session_b = RunSession(agent_run_id="run-b")
     frame_a = _frame("run-a", "frame-a", FrameExecutionPolicy())
@@ -72,17 +69,8 @@ async def test_interleaved_sessions_keep_cancel_and_records_isolated() -> None:
     session_a.register_frame(frame_a)
     session_b.register_frame(frame_b)
 
-    async def cancel_one() -> None:
-        await asyncio.sleep(0)
-        session_a.cancel_event.set()
-
-    task = asyncio.create_task(cancel_one())
-    await asyncio.sleep(0)
     record = session_b.register_call(frame_b, "action-b")
-    await task
 
-    assert session_a.cancel_event.is_set()
-    assert not session_b.cancel_event.is_set()
     assert session_a.call_records == {}
     assert session_b.call_records[("frame-b", "action-b")] is record
 

--- a/tests/unit/alice/runtime/test_control_flow_refactor_baseline.py
+++ b/tests/unit/alice/runtime/test_control_flow_refactor_baseline.py
@@ -108,12 +108,12 @@ def test_run_session_keeps_frames_and_calls_run_local() -> None:
     assert session.call_records[("frame-a", "action-1")] is record
 
 
-def test_mtp_cancel_event_is_invocation_local() -> None:
+def test_mtp_executor_keeps_runtime_stateless() -> None:
     koakuma = SimpleNamespace()
     executor = KoakumaMTPExecutor(koakuma)
 
-    assert not hasattr(executor, "set_cancel_event")
-    assert not hasattr(koakuma, "cancel_event")
+    assert vars(executor) == {"_koakuma": koakuma}
+    assert vars(koakuma) == {}
 
 
 def test_mtp_context_contains_only_frame_coordinates() -> None:

--- a/tests/unit/alice/runtime/test_streaming.py
+++ b/tests/unit/alice/runtime/test_streaming.py
@@ -132,4 +132,3 @@ async def test_agent_run_stream_wakes_consumer_when_runner_is_cancelled() -> Non
 
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(anext(events), timeout=1)
-    assert session.cancel_event.is_set()

--- a/tests/unit/alice/runtime/test_streaming.py
+++ b/tests/unit/alice/runtime/test_streaming.py
@@ -132,3 +132,25 @@ async def test_agent_run_stream_wakes_consumer_when_runner_is_cancelled() -> Non
 
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(anext(events), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_runner_cleanup_error_does_not_replace_consumer_cancellation() -> None:
+    session = RunSession(agent_run_id="run-1")
+    stream = AgentRunStream(session)
+    runner_started = asyncio.Event()
+
+    async def runner() -> FrameExecutionResult:
+        runner_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            raise RuntimeError("runner cleanup failed")
+
+    events = stream.events(runner())
+    pull_task = asyncio.create_task(anext(events))
+    await runner_started.wait()
+    pull_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await pull_task

--- a/tests/unit/gateway/test_phase3a_system.py
+++ b/tests/unit/gateway/test_phase3a_system.py
@@ -30,7 +30,6 @@ async def test_gateway_service_delegates_to_workflow() -> None:
         "hello",
         identity=identity,
         ingress_mode=GatewayIngressMode.ACTIVE_CHAT,
-        cancel_event=None,
         request_timeout_ms=8000,
     )
 
@@ -39,7 +38,6 @@ async def test_gateway_service_delegates_to_workflow() -> None:
         "hello",
         identity=identity,
         ingress_mode=GatewayIngressMode.ACTIVE_CHAT,
-        cancel_event=None,
         request_timeout_ms=8000,
     )
 

--- a/tests/unit/gateway/test_phase3f_request_control.py
+++ b/tests/unit/gateway/test_phase3f_request_control.py
@@ -10,7 +10,6 @@ import pytest
 import hivememory
 from hivememory.core.models import Identity
 from hivememory.core.protocol.gateway import (
-    GatewayCancelledError,
     GatewayIngressMode,
     GatewayTimeoutError,
 )
@@ -28,7 +27,7 @@ from hivememory.system.runtime.events import RecordingRuntimeEventSink
 
 
 @pytest.mark.asyncio
-async def test_cancel_stops_current_provider_invoke_and_emits_cancelled() -> None:
+async def test_task_cancel_stops_current_provider_invoke_and_propagates() -> None:
     bus = GlobalSystemBus()
     started = asyncio.Event()
     provider_cancelled = asyncio.Event()
@@ -47,24 +46,22 @@ async def test_cancel_stops_current_provider_invoke_and_emits_cancelled() -> Non
         global_bus=bus,
         runtime_events=events,
     )
-    cancel_event = asyncio.Event()
     task = asyncio.create_task(
         GatewayService(runtime).process(
             "需要取消的问题",
             identity=Identity(user_id="u1"),
             ingress_mode=GatewayIngressMode.ACTIVE_CHAT,
-            cancel_event=cancel_event,
         )
     )
 
     await started.wait()
-    cancel_event.set()
+    task.cancel()
 
-    with pytest.raises(GatewayCancelledError):
+    with pytest.raises(asyncio.CancelledError):
         await task
     assert provider_cancelled.is_set()
     event_types = [event.event_type for event in events.events]
-    assert RuntimeEventType.GATEWAY_WORKFLOW_CANCELLED.value in event_types
+    assert RuntimeEventType.GATEWAY_WORKFLOW_CANCELLED.value not in event_types
     assert RuntimeEventType.GATEWAY_WORKFLOW_FAILED.value not in event_types
 
 
@@ -122,23 +119,31 @@ async def test_exhausted_deadline_without_fallback_raises_timeout() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_wins_when_invoke_completes_at_the_same_time() -> None:
+async def test_workflow_propagates_task_cancellation_without_business_result() -> None:
+    bus = GlobalSystemBus()
+    started = asyncio.Event()
+
+    async def slow_topics(**_kwargs):
+        started.set()
+        await asyncio.Event().wait()
+
+    bus.register(PatchouliRoutes.TOPIC_LIST_ACTIVE, slow_topics)
     runtime = GatewayRuntime(
         config=SystemGatewayConfig(),
-        global_bus=GlobalSystemBus(),
+        global_bus=bus,
     )
-    cancel_event = asyncio.Event()
-
-    async def complete_and_cancel() -> str:
-        cancel_event.set()
-        return "completed"
-
-    with pytest.raises(GatewayCancelledError):
-        await runtime.workflow._invoke_with_control(
-            complete_and_cancel(),
-            timeout=1.0,
-            cancel_event=cancel_event,
+    task = asyncio.create_task(
+        runtime.workflow.run(
+            "问题",
+            identity=Identity(user_id="u1"),
+            ingress_mode=GatewayIngressMode.ACTIVE_CHAT,
         )
+    )
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 def test_legacy_gateway_root_exports_are_removed() -> None:

--- a/tests/unit/server/routers/test_chat.py
+++ b/tests/unit/server/routers/test_chat.py
@@ -17,7 +17,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from hivememory.server.models.chat import ChatRequest
-from hivememory.server.routers.chat import chat, router
+from hivememory.server.routers.chat import _cancel_and_join, chat, router
 
 
 def _create_test_app(mock_service):
@@ -49,6 +49,31 @@ def _parse_sse_events(response_text: str):
     if current_event:
         events.append(current_event)
     return events
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_join_preserves_owner_cancellation() -> None:
+    child_started = asyncio.Event()
+    child_cleanup_started = asyncio.Event()
+
+    async def child() -> None:
+        child_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            child_cleanup_started.set()
+            await asyncio.Event().wait()
+
+    child_task = asyncio.create_task(child())
+    await child_started.wait()
+    join_task = asyncio.create_task(_cancel_and_join(child_task))
+    await asyncio.wait_for(child_cleanup_started.wait(), timeout=1)
+    join_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await join_task
+
+    assert child_task.done()
 
 
 class TestChatRouter:

--- a/tests/unit/server/routers/test_chat.py
+++ b/tests/unit/server/routers/test_chat.py
@@ -355,3 +355,92 @@ class TestChatRouter:
             generation_id,
             reason="client_disconnected",
         )
+
+    @pytest.mark.asyncio
+    async def test_asgi_cancellation_joins_pending_pull_before_closing_stream(self):
+        mock_service = MagicMock()
+        pull_started = asyncio.Event()
+        stream_closed = asyncio.Event()
+        pull_task = None
+
+        async def fake_stream(**kwargs):
+            nonlocal pull_task
+            yield {
+                "event": "generation_id",
+                "data": {"generation_id": kwargs["generation_id"]},
+            }
+            pull_task = asyncio.current_task()
+            pull_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                stream_closed.set()
+
+        class FakeRequest:
+            async def is_disconnected(self):
+                return False
+
+        mock_service.chat_stream = MagicMock(side_effect=lambda **kw: fake_stream(**kw))
+        mock_service.cancel_generation = MagicMock()
+
+        response = await chat(
+            request=FakeRequest(),
+            body=ChatRequest(message="hello", user_id="test"),
+            service=mock_service,
+        )
+
+        first_chunk = await response.body_iterator.__anext__()
+        assert first_chunk["event"] == "generation_id"
+
+        next_chunk = asyncio.create_task(response.body_iterator.__anext__())
+        await pull_started.wait()
+        next_chunk.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await next_chunk
+
+        assert stream_closed.is_set()
+        assert pull_task is not None
+        assert pull_task.done()
+        assert pull_task.cancelled()
+        generation_id = mock_service.chat_stream.call_args.kwargs["generation_id"]
+        mock_service.cancel_generation.assert_called_once_with(
+            generation_id,
+            reason="client_disconnected",
+        )
+
+    @pytest.mark.asyncio
+    async def test_sse_iterator_close_closes_chat_stream(self):
+        mock_service = MagicMock()
+        stream_closed = asyncio.Event()
+
+        async def fake_stream(**kwargs):
+            try:
+                yield {
+                    "event": "generation_id",
+                    "data": {"generation_id": kwargs["generation_id"]},
+                }
+                yield {"event": "token", "data": {"content": "late"}}
+            finally:
+                stream_closed.set()
+
+        class FakeRequest:
+            async def is_disconnected(self):
+                return False
+
+        mock_service.chat_stream = MagicMock(side_effect=lambda **kw: fake_stream(**kw))
+
+        response = await chat(
+            request=FakeRequest(),
+            body=ChatRequest(message="hello", user_id="test"),
+            service=mock_service,
+        )
+
+        first_chunk = await response.body_iterator.__anext__()
+        assert first_chunk["event"] == "generation_id"
+
+        await response.body_iterator.aclose()
+
+        assert stream_closed.is_set()
+        with pytest.raises(StopAsyncIteration):
+            await response.body_iterator.__anext__()

--- a/tests/unit/server/routers/test_chat.py
+++ b/tests/unit/server/routers/test_chat.py
@@ -7,18 +7,17 @@ Chat 路由单元测试
     3. 异常处理 — SSE error 事件
 """
 
-import json
 import asyncio
-import pytest
+import json
+from unittest.mock import MagicMock
 from uuid import uuid4
-from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from hivememory.server.routers.chat import router
-from hivememory.server.routers.chat import chat
 from hivememory.server.models.chat import ChatRequest
+from hivememory.server.routers.chat import chat, router
 
 
 def _create_test_app(mock_service):
@@ -221,6 +220,32 @@ class TestChatRouter:
         assert "token" not in event_types
         assert events[0]["data"]["message"] == "cleared"
         assert events[0]["data"]["client_action"] == {"type": "clear_chat"}
+
+    def test_stop_route_projects_cancel_result(self):
+        mock_service = MagicMock()
+        mock_service.cancel_generation.return_value = MagicMock(
+            generation_id="gen-1",
+            cancelled=False,
+            status="not_found",
+            reason="user_requested",
+        )
+
+        app = _create_test_app(mock_service)
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/v1/chat/stop",
+            json={"generation_id": "gen-1"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "generation_id": "gen-1",
+            "cancelled": False,
+            "status": "not_found",
+            "reason": "user_requested",
+        }
+        mock_service.cancel_generation.assert_called_once_with("gen-1")
 
     def test_uuid_payload_is_serializable(self):
         mock_service = MagicMock()

--- a/tests/unit/system/application/test_gateway_chat_flow.py
+++ b/tests/unit/system/application/test_gateway_chat_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -9,7 +10,6 @@ import pytest
 from hivememory.core.protocol.gateway import (
     CommandExecutionResult,
     CommandExecutionStatus,
-    GatewayCancelledError,
     GatewayCommandOutcome,
     GatewayDecision,
     GatewayDecisionOutcome,
@@ -122,22 +122,24 @@ async def test_streaming_command_emits_result_and_done_only() -> None:
 @pytest.mark.asyncio
 async def test_gateway_cancellation_maps_to_cancelled_agent_outcomes() -> None:
     bus = GlobalSystemBus()
-    bus.register(
-        GlobalRoutes.GATEWAY_PROCESS,
-        AsyncMock(side_effect=GatewayCancelledError("cancelled")),
-    )
+    started = asyncio.Event()
+
+    async def gateway(**_kwargs):
+        started.set()
+        await asyncio.Event().wait()
+
+    bus.register(GlobalRoutes.GATEWAY_PROCESS, gateway)
     service = ChatApplicationService(bus)
 
-    result = await service.chat("问题", "u1")
-    stream_events = [event async for event in service.chat_stream("问题", "u1")]
+    task = asyncio.create_task(service.chat("问题", "u1", generation_id="gen-gateway"))
+    await started.wait()
+    stop_result = service.cancel_generation("gen-gateway")
+    result = await task
+
+    assert stop_result.cancelled is True
 
     assert result.kind == "agent"
     assert result.agent_run_result.status == "cancelled"
-    assert [event["event"] for event in stream_events] == [
-        "generation_id",
-        "done",
-    ]
-    assert stream_events[-1]["data"]["status"] == "cancelled"
 
 
 @pytest.mark.asyncio
@@ -243,3 +245,147 @@ async def test_streaming_failed_agent_run_preserves_failed_done_status() -> None
     assert events[-1]["data"]["status"] == AgentRunStatus.FAILED.value
     assert events[-1]["data"]["stopped"] is True
     cleanup.assert_awaited_once_with(prepared_run=prepared)
+
+
+@pytest.mark.asyncio
+async def test_stop_during_prepare_waits_for_prepare_then_skips_alice_and_finalize() -> None:
+    bus = GlobalSystemBus()
+    prepare_started = asyncio.Event()
+    release_prepare = asyncio.Event()
+    prepare_cancelled = False
+    prepared = AsyncMock()
+    prepared.agent_run_context = object()
+    prepared.generation_options = None
+    prepared.topic_id = "topic-1"
+
+    async def prepare(**_kwargs):
+        nonlocal prepare_cancelled
+        prepare_started.set()
+        try:
+            await release_prepare.wait()
+        except asyncio.CancelledError:
+            prepare_cancelled = True
+            raise
+        return prepared
+
+    alice = AsyncMock()
+    finalize = AsyncMock()
+    cleanup = AsyncMock(return_value=True)
+    bus.register(GlobalRoutes.GATEWAY_PROCESS, AsyncMock(return_value=_decision_outcome()))
+    bus.register(GlobalRoutes.PATCHOULI_PREPARE_AGENT_RUN, prepare)
+    bus.register(GlobalRoutes.ALICE_RUN_AGENT, alice)
+    bus.register(GlobalRoutes.PATCHOULI_FINALIZE_AGENT_RUN, finalize)
+    bus.register(GlobalRoutes.PATCHOULI_CLEANUP_PREPARED_AGENT_RUN, cleanup)
+    service = ChatApplicationService(bus)
+
+    task = asyncio.create_task(service.chat("问题", "u1", generation_id="gen-prepare"))
+    await prepare_started.wait()
+    stop_result = service.cancel_generation("gen-prepare")
+    release_prepare.set()
+    result = await task
+
+    assert stop_result.cancelled is True
+    assert prepare_cancelled is False
+    assert result.agent_run_result.status == AgentRunStatus.CANCELLED.value
+    alice.assert_not_awaited()
+    finalize.assert_not_awaited()
+    cleanup.assert_awaited_once_with(prepared_run=prepared)
+
+
+@pytest.mark.asyncio
+async def test_stream_stop_cancels_current_alice_pull_and_closes_stream() -> None:
+    bus = GlobalSystemBus()
+    pull_started = asyncio.Event()
+    stream_closed = asyncio.Event()
+    prepared = AsyncMock()
+    prepared.agent_run_context = object()
+    prepared.generation_options = None
+    prepared.topic_id = "topic-1"
+    prepared.stream_prelude.topic_id = "topic-1"
+    prepared.stream_prelude.is_new_topic = False
+    prepared.stream_prelude.pool_topics = []
+    prepared.stream_prelude.memory_refs = []
+
+    async def alice_stream():
+        try:
+            pull_started.set()
+            await asyncio.Event().wait()
+            yield {"event": "token", "data": {"content": "late"}}
+        finally:
+            stream_closed.set()
+
+    finalize = AsyncMock()
+    cleanup = AsyncMock(return_value=True)
+    bus.register(GlobalRoutes.GATEWAY_PROCESS, AsyncMock(return_value=_decision_outcome()))
+    bus.register(GlobalRoutes.PATCHOULI_PREPARE_AGENT_RUN, AsyncMock(return_value=prepared))
+    bus.register(GlobalRoutes.ALICE_RUN_AGENT_STREAM, AsyncMock(return_value=alice_stream()))
+    bus.register(GlobalRoutes.PATCHOULI_FINALIZE_AGENT_RUN, finalize)
+    bus.register(GlobalRoutes.PATCHOULI_CLEANUP_PREPARED_AGENT_RUN, cleanup)
+    service = ChatApplicationService(bus)
+
+    task = asyncio.create_task(
+        _collect_stream(service, generation_id="gen-stream-cancel")
+    )
+    await pull_started.wait()
+    stop_result = service.cancel_generation("gen-stream-cancel")
+    events = await task
+
+    assert stop_result.cancelled is True
+    assert stream_closed.is_set()
+    assert events[-1]["event"] == "done"
+    assert events[-1]["data"]["status"] == "cancelled"
+    finalize.assert_not_awaited()
+    cleanup.assert_awaited_once_with(prepared_run=prepared)
+
+
+@pytest.mark.asyncio
+async def test_stop_during_finalize_is_rejected_and_finalize_completes() -> None:
+    bus = GlobalSystemBus()
+    finalize_started = asyncio.Event()
+    release_finalize = asyncio.Event()
+    prepared = AsyncMock()
+    prepared.agent_run_context = object()
+    prepared.generation_options = None
+    prepared.topic_id = "topic-1"
+
+    async def finalize(**_kwargs):
+        finalize_started.set()
+        await release_finalize.wait()
+        return []
+
+    cleanup = AsyncMock(return_value=True)
+    bus.register(GlobalRoutes.GATEWAY_PROCESS, AsyncMock(return_value=_decision_outcome()))
+    bus.register(GlobalRoutes.PATCHOULI_PREPARE_AGENT_RUN, AsyncMock(return_value=prepared))
+    bus.register(
+        GlobalRoutes.ALICE_RUN_AGENT,
+        AsyncMock(return_value=AgentRunResult(final_text="完成")),
+    )
+    bus.register(GlobalRoutes.PATCHOULI_FINALIZE_AGENT_RUN, finalize)
+    bus.register(GlobalRoutes.PATCHOULI_CLEANUP_PREPARED_AGENT_RUN, cleanup)
+    service = ChatApplicationService(bus)
+
+    task = asyncio.create_task(service.chat("问题", "u1", generation_id="gen-finalize"))
+    await finalize_started.wait()
+    stop_result = service.cancel_generation("gen-finalize")
+    release_finalize.set()
+    result = await task
+
+    assert stop_result.cancelled is False
+    assert stop_result.reason == "already_finalizing"
+    assert result.agent_run_result.status == AgentRunStatus.COMPLETED.value
+    cleanup.assert_not_awaited()
+
+
+async def _collect_stream(
+    service: ChatApplicationService,
+    *,
+    generation_id: str,
+) -> list[dict]:
+    return [
+        event
+        async for event in service.chat_stream(
+            "问题",
+            "u1",
+            generation_id=generation_id,
+        )
+    ]

--- a/tests/unit/system/test_cancel_hardening.py
+++ b/tests/unit/system/test_cancel_hardening.py
@@ -19,7 +19,8 @@ from hivememory.core.protocol.models import AgentRunResult, AgentRunStatus
 from hivememory.system.runtime.control import (
     ChatGenerationRun,
     ChatGenerationRunRegistry,
-    ChatGenerationRunStatus,
+    ChatRunOutcome,
+    ChatRunPhase,
 )
 
 # ─── RuntimeControlRegistry ─────────────────────────────────────────────────
@@ -28,15 +29,15 @@ class TestChatGenerationRunRegistry:
     def setup_method(self):
         self.registry = ChatGenerationRunRegistry()
 
-    def test_cancel_sets_event_and_returns_result(self):
+    def test_cancel_records_stop_and_returns_result(self):
         run = ChatGenerationRun(generation_id="gen-1")
         self.registry.register(run)
 
         result = self.registry.cancel("gen-1")
 
         assert result.cancelled is True
-        assert result.status == ChatGenerationRunStatus.CANCELLING.value
-        assert run.cancel_event.is_set()
+        assert result.status == ChatRunOutcome.STOP_REQUESTED.value
+        assert run.outcome is ChatRunOutcome.STOP_REQUESTED
 
     def test_cancel_idempotent(self):
         run = ChatGenerationRun(generation_id="gen-2")
@@ -47,6 +48,7 @@ class TestChatGenerationRunRegistry:
 
         assert r1.cancelled is True
         assert r2.cancelled is True  # 重复 cancel 不报错
+        assert r2.reason == r1.reason
 
     def test_cancel_unknown_generation_id_returns_not_found(self):
         result = self.registry.cancel("nonexistent")
@@ -56,14 +58,15 @@ class TestChatGenerationRunRegistry:
     def test_close_removes_run(self):
         run = ChatGenerationRun(generation_id="gen-3")
         self.registry.register(run)
-        self.registry.close("gen-3", ChatGenerationRunStatus.COMPLETED)
+        self.registry.close("gen-3")
         assert self.registry.get("gen-3") is None
 
-    def test_run_cancelled_property(self):
+    def test_run_stop_outcome(self):
         run = ChatGenerationRun(generation_id="gen-4")
-        assert run.cancelled is False
-        run.request_cancel()
-        assert run.cancelled is True
+        assert run.outcome is ChatRunOutcome.RUNNING
+        run.enter_phase(ChatRunPhase.ALICE)
+        run.request_stop()
+        assert run.outcome is ChatRunOutcome.STOP_REQUESTED
 
 
 # ─── AgentRunResult.status ───────────────────────────────────────────────────

--- a/tests/unit/system/test_chat_run_control_contract.py
+++ b/tests/unit/system/test_chat_run_control_contract.py
@@ -1,0 +1,135 @@
+"""Chat Run 取消控制契约测试。"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from hivememory.system.application.chat_service import (
+    _ChatRunCancelled,
+    _run_interruptible,
+)
+from hivememory.system.runtime.control import (
+    ChatGenerationRun,
+    ChatGenerationRunRegistry,
+    ChatRunOutcome,
+    ChatRunPhase,
+)
+
+
+@pytest.mark.asyncio
+async def test_gateway_stop_cancels_bound_task_immediately() -> None:
+    run = ChatGenerationRun(generation_id="generation-1")
+    blocker = asyncio.Event()
+    task = asyncio.create_task(blocker.wait())
+    run.bind_phase(ChatRunPhase.GATEWAY, task)
+
+    result = run.request_stop()
+
+    assert result.accepted is True
+    assert result.reason == "user_requested"
+    assert run.outcome is ChatRunOutcome.STOP_REQUESTED
+    assert run.phase is ChatRunPhase.GATEWAY
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_prepare_stop_records_request_without_cancelling_prepare_task() -> None:
+    run = ChatGenerationRun(generation_id="generation-2")
+    run.enter_phase(ChatRunPhase.PREPARE)
+    blocker = asyncio.Event()
+    prepare_task = asyncio.create_task(blocker.wait())
+
+    result = run.request_stop("during_prepare")
+
+    assert result.accepted is True
+    assert run.outcome is ChatRunOutcome.STOP_REQUESTED
+    assert run.stop_reason == "during_prepare"
+    assert prepare_task.cancelled() is False
+    prepare_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await prepare_task
+
+
+def test_finalize_and_terminal_stop_are_rejected() -> None:
+    finalizing = ChatGenerationRun(generation_id="generation-3")
+    finalizing.enter_phase(ChatRunPhase.FINALIZE)
+    result = finalizing.request_stop()
+    assert result.accepted is False
+    assert result.reason == "already_finalizing"
+    assert finalizing.outcome is ChatRunOutcome.RUNNING
+
+    terminal = ChatGenerationRun(generation_id="generation-4")
+    terminal.phase = ChatRunPhase.TERMINAL
+    terminal.outcome = ChatRunOutcome.COMPLETED
+    result = terminal.request_stop()
+    assert result.accepted is False
+    assert result.reason == "already_terminal"
+    assert terminal.outcome is ChatRunOutcome.COMPLETED
+
+
+def test_repeated_stop_keeps_first_reason_and_does_not_cancel_again() -> None:
+    run = ChatGenerationRun(generation_id="generation-5")
+    task = MagicMock()
+    task.done.return_value = False
+    run.bind_phase(ChatRunPhase.ALICE, task)
+
+    first = run.request_stop("first_reason")
+    second = run.request_stop("second_reason")
+
+    assert first.accepted is True
+    assert second.accepted is True
+    assert second.reason == "first_reason"
+    task.cancel.assert_called_once_with()
+
+
+def test_registry_not_found_and_terminal_results_are_stable() -> None:
+    registry = ChatGenerationRunRegistry()
+
+    missing = registry.cancel("missing-generation")
+    assert missing.cancelled is False
+    assert missing.status == "not_found"
+
+    run = ChatGenerationRun(generation_id="generation-6")
+    run.phase = ChatRunPhase.TERMINAL
+    run.outcome = ChatRunOutcome.FAILED
+    registry.register(run)
+
+    terminal = registry.cancel(run.generation_id)
+    assert terminal.cancelled is False
+    assert terminal.reason == "already_terminal"
+    assert run.outcome is ChatRunOutcome.FAILED
+
+
+def test_stop_after_bound_task_finished_is_accepted_without_second_cancel() -> None:
+    run = ChatGenerationRun(generation_id="generation-7")
+    task = MagicMock()
+    task.done.return_value = True
+    run.bind_phase(ChatRunPhase.GATEWAY, task)
+
+    result = run.request_stop("late_stop")
+
+    assert result.accepted is True
+    assert result.reason == "late_stop"
+    task.cancel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_owner_task_cancellation_is_not_translated_to_chat_run_cancelled() -> None:
+    run = ChatGenerationRun(generation_id="generation-8")
+    blocker = asyncio.Event()
+
+    async def operation():
+        await blocker.wait()
+
+    task = asyncio.create_task(_run_interruptible(run, ChatRunPhase.GATEWAY, operation))
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert run.outcome is ChatRunOutcome.RUNNING
+    assert not isinstance(task.exception() if task.done() and not task.cancelled() else None, _ChatRunCancelled)


### PR DESCRIPTION
## 描述

重构了chat run全链路的取消事件处理，删除了所有散乱的取消检查点与cancel error捕获，改为使用asyncio原生的task.cancel进行任意深度的取消响应，并集中在最上层进行异常捕获

## 类型

- [ ] Bug 修复 (fix)
- [ ] 新功能 (feat)
- [x] 代码重构 (refactor)
- [ ] 文档更新 (docs)
- [ ] 代码风格更新 (style)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 构建/CI 更新 (build/ci)
- [ ] 其他变更 (chore)

## 相关 Issue

无

## 检查清单

- [x] 我已经阅读了项目的贡献指南
- [x] 我已经自我审查了代码，并确保其符合项目的代码风格与规范
- [x] 代码通过了 lint 检查
- [x] 添加了必要的测试用例并全部通过
- [x] 文档已更新（如有必要）

## 测试

修改并运行了已有测试

## 附加信息

无
